### PR TITLE
LG-1897 Rescure Faraday timeout errors when sending SMS and Voice messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity-telephony (0.0.6)
+    identity-telephony (0.0.7)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n

--- a/lib/telephony/twilio/programmable_api_client.rb
+++ b/lib/telephony/twilio/programmable_api_client.rb
@@ -21,6 +21,7 @@ module Telephony
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
       def handle_twilio_rest_error(err)
         error_code = err.code
         error_message = err.message
@@ -40,6 +41,11 @@ module Telephony
         else
           raise TelephonyError, exception_message
         end
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def handle_faraday_error(err)
+        raise ApiConnectionError, "Faraday error: #{err.class} - #{err.message}"
       end
     end
   end

--- a/lib/telephony/twilio/programmable_sms_sender.rb
+++ b/lib/telephony/twilio/programmable_sms_sender.rb
@@ -9,8 +9,10 @@ module Telephony
           to: to,
           body: message,
         )
-      rescue ::Twilio::REST::RestError => err
-        handle_twilio_rest_error(err)
+      rescue ::Twilio::REST::RestError => e
+        handle_twilio_rest_error(e)
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+        handle_faraday_error(e)
       end
     end
   end

--- a/lib/telephony/twilio/programmable_voice_sender.rb
+++ b/lib/telephony/twilio/programmable_voice_sender.rb
@@ -8,8 +8,10 @@ module Telephony
           url: callback_url_for_message(message),
           record: Telephony.config.twilio_record_voice,
         )
-      rescue ::Twilio::REST::RestError => err
-        handle_twilio_rest_error(err)
+      rescue ::Twilio::REST::RestError => e
+        handle_twilio_rest_error(e)
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+        handle_faraday_error(e)
       end
 
       private

--- a/spec/support/shared_examples_for_twilio_api.rb
+++ b/spec/support/shared_examples_for_twilio_api.rb
@@ -85,5 +85,29 @@ shared_examples 'a twilio api client' do
         )
       end
     end
+
+    context 'when Faraday times out' do
+      let(:error) { Faraday::TimeoutError.new('test error') }
+      let(:raised_error_message) { 'Faraday error: Faraday::TimeoutError - test error' }
+
+      it 'raises a API connection error' do
+        expect { subject.send(message: 'hello!', to: '+11234567890') }.to raise_error(
+          Telephony::ApiConnectionError,
+          raised_error_message,
+        )
+      end
+    end
+
+    context 'when Faraday fails to make a connection' do
+      let(:error) { Faraday::ConnectionFailed.new('test error') }
+      let(:raised_error_message) { 'Faraday error: Faraday::ConnectionFailed - test error' }
+
+      it 'raises a API connection error' do
+        expect { subject.send(message: 'hello!', to: '+11234567890') }.to raise_error(
+          Telephony::ApiConnectionError,
+          raised_error_message,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
**Why**: We thought these would be raises as Twilio::RestErrors but they are not. This commit adds an additional check for Faraday errors and handles them appropriately