### PR TITLE
Split up pinpoint SMS and Voice configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,24 @@ This gem can be configured in this manner:
 ```ruby
 Telephony.config do |c|
   c.adapter = :twilio
-  c.twilio_numbers = ['12223334444', '15556667777']
-  c.twilio_sid = 'example-twilio-sid'
-  c.twilio_auth_token = 'example-twilio-auth-token'
-  c.twilio_messaging_service_sid = 'example-twilio-messaging-service-sid'
-  c.twilio_verify_api_key = 'example-twilio-verify-api-key'
-  c.twilio_voice_callback_encryption_key = '#### 32 byte encryption key ####'
-  c.twilio_voice_callback_base_url = 'https://example.com/api/twilo_voice'
-  c.twilio_timeout = 5 # This is optional. The default is `5`
-  c.twilio_record_voice = false # This is optional. The default is `false`
+  c.twilio.numbers = ['12223334444', '15556667777']
+  c.twilio.sid = 'example-twilio-sid'
+  c.twilio.auth_token = 'example-twilio-auth-token'
+  c.twilio.messaging_service_sid = 'example-twilio-messaging-service-sid'
+  c.twilio.verify_api_key = 'example-twilio-verify-api-key'
+  c.twilio.voice_callback_encryption_key = '#### 32 byte encryption key ####'
+  c.twilio.voice_callback_base_url = 'https://example.com/api/twilo_voice'
+  c.twilio.timeout = 5 # This is optional. The default is `5`
+  c.twilio.record_voice = false # This is optional. The default is `false`
+
+  c.pinpoint.sms.region = 'us-west-2' # This is optional, us-west-2 is the default
+  c.pinpoint.sms.application_id = 'fake-pinpoint-application-id-sms'
+  c.pinpoint.sms.shortcode = '123456'
+  c.pinpoint.sms.longcode_pool = ['+12223334444', '+15556667777']
+
+  c.pinpoint.voice.region = 'us-west-2' # This is optional, us-west-2 is the default
+  c.pinpoint.voice.application_id = 'fake-pinpoint-application-id-sms'
+  c.pinpoint.voice.longcode_pool = ['+12223334444', '+15556667777']
 end
 ```
 

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -1,27 +1,42 @@
 module Telephony
+  TwilioConfiguration = Struct.new(
+    :timeout,
+    :numbers,
+    :sid,
+    :auth_token,
+    :messaging_service_sid,
+    :record_voice,
+    :verify_api_key,
+    :voice_callback_encryption_key,
+    :voice_callback_base_url,
+    keyword_init: true,
+  )
+
+  PinpointConfiguration = Struct.new(
+    :sms,
+    :voice,
+    keyword_init: true,
+  )
+  PINPOINT_CONFIGURATION_NAMES = [
+    :region, :access_key_id, :secret_access_key, :application_id, :longcode_pool
+  ].freeze
+  PinpointVoiceConfiguration = Struct.new(*PINPOINT_CONFIGURATION_NAMES)
+  PinpointSmsConfiguration = Struct.new(:shortcode, *PINPOINT_CONFIGURATION_NAMES)
+
   class Configuration
-    attr_writer   :adapter
-    attr_accessor :twilio_timeout,
-                  :twilio_numbers,
-                  :twilio_sid,
-                  :twilio_auth_token,
-                  :twilio_messaging_service_sid,
-                  :twilio_record_voice,
-                  :twilio_verify_api_key,
-                  :twilio_voice_callback_encryption_key,
-                  :twilio_voice_callback_base_url,
-                  :pinpoint_region,
-                  :pinpoint_access_key_id,
-                  :pinpoint_secret_access_key,
-                  :pinpoint_application_id,
-                  :pinpoint_shortcode,
-                  :pinpoint_longcode_pool
+    attr_writer :adapter
+    attr_reader :twilio, :pinpoint
 
     def initialize
       @adapter = :twilio
-      self.twilio_timeout = 5
-      self.twilio_record_voice = false
-      self.pinpoint_region = 'us-west-2'
+      @twilio = TwilioConfiguration.new(timeout: 5, record_voice: false)
+      pinpoint_voice = PinpointVoiceConfiguration.new(
+        region: 'us-west-2',
+      )
+      pinpoint_sms = PinpointSmsConfiguration.new(
+        region: 'us-west-2',
+      )
+      @pinpoint = PinpointConfiguration.new(voice: pinpoint_voice, sms: pinpoint_sms)
     end
 
     def adapter

--- a/lib/telephony/pinpoint/longcode_sms_sender.rb
+++ b/lib/telephony/pinpoint/longcode_sms_sender.rb
@@ -4,7 +4,7 @@ module Telephony
       protected
 
       def origination_number
-        Telephony.config.pinpoint_longcode_pool.sample
+        Telephony.config.pinpoint.sms.longcode_pool.sample
       end
     end
   end

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -14,7 +14,7 @@ module Telephony
       # rubocop:disable Metrics/MethodLength
       def send(message:, to:)
         response = pinpoint_client.send_messages(
-          application_id: Telephony.config.pinpoint_application_id,
+          application_id: Telephony.config.pinpoint.sms.application_id,
           message_request: {
             addresses: {
               to => {
@@ -37,16 +37,16 @@ module Telephony
       protected
 
       def origination_number
-        Telephony.config.pinpoint_shortcode
+        Telephony.config.pinpoint.sms.shortcode
       end
 
       private
 
       def pinpoint_client
         @pinpoint_client ||= Aws::Pinpoint::Client.new(
-          region: Telephony.config.pinpoint_region,
-          access_key_id: Telephony.config.pinpoint_access_key_id,
-          secret_access_key: Telephony.config.pinpoint_secret_access_key,
+          region: Telephony.config.pinpoint.sms.region,
+          access_key_id: Telephony.config.pinpoint.sms.access_key_id,
+          secret_access_key: Telephony.config.pinpoint.sms.secret_access_key,
         )
       end
 

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -13,7 +13,7 @@ module Telephony
             },
           },
           destination_phone_number: to,
-          origination_phone_number: Telephony.config.pinpoint_longcode_pool.sample,
+          origination_phone_number: Telephony.config.pinpoint.voice.longcode_pool.sample,
         )
       rescue Aws::PinpointSMSVoice::Errors::ServiceError => e
         handle_pinpoint_error(e)
@@ -24,9 +24,9 @@ module Telephony
 
       def pinpoint_client
         @pinpoint_client ||= Aws::PinpointSMSVoice::Client.new(
-          region: Telephony.config.pinpoint_region,
-          access_key_id: Telephony.config.pinpoint_access_key_id,
-          secret_access_key: Telephony.config.pinpoint_secret_access_key,
+          region: Telephony.config.pinpoint.voice.region,
+          access_key_id: Telephony.config.pinpoint.voice.access_key_id,
+          secret_access_key: Telephony.config.pinpoint.voice.secret_access_key,
         )
       end
 

--- a/lib/telephony/twilio/programmable_api_client.rb
+++ b/lib/telephony/twilio/programmable_api_client.rb
@@ -5,8 +5,8 @@ module Telephony
     class ProgrammableApiClient
       def twilio_client
         @twilio_client ||= ::Twilio::REST::Client.new(
-          Telephony.config.twilio_sid,
-          Telephony.config.twilio_auth_token,
+          Telephony.config.twilio.sid,
+          Telephony.config.twilio.auth_token,
           nil,
           nil,
           http_client,
@@ -15,7 +15,7 @@ module Telephony
 
       def http_client
         @http_client ||= begin
-          client = ::Twilio::HTTP::Client.new(timeout: Telephony.config.twilio_timeout.to_i)
+          client = ::Twilio::HTTP::Client.new(timeout: Telephony.config.twilio.timeout.to_i)
           client.adapter = :typhoeus
           client
         end

--- a/lib/telephony/twilio/programmable_sms_sender.rb
+++ b/lib/telephony/twilio/programmable_sms_sender.rb
@@ -5,7 +5,7 @@ module Telephony
     class ProgrammableSmsSender < ProgrammableApiClient
       def send(message:, to:)
         twilio_client.messages.create(
-          messaging_service_sid: Telephony.config.twilio_messaging_service_sid,
+          messaging_service_sid: Telephony.config.twilio.messaging_service_sid,
           to: to,
           body: message,
         )

--- a/lib/telephony/twilio/programmable_voice_message.rb
+++ b/lib/telephony/twilio/programmable_voice_message.rb
@@ -27,7 +27,7 @@ module Telephony
       end
 
       def callback_url
-        uri = URI.parse(Telephony.config.twilio_voice_callback_base_url)
+        uri = URI.parse(Telephony.config.twilio.voice_callback_base_url)
         uri.query = "encrypted_message=#{CGI.escape(to_encrypted_message)}"
         uri.to_s
       end

--- a/lib/telephony/twilio/programmable_voice_message_encryptor.rb
+++ b/lib/telephony/twilio/programmable_voice_message_encryptor.rb
@@ -72,7 +72,7 @@ module Telephony
       end
 
       def self.encryption_key
-        Base64.decode64(Telephony.config.twilio_voice_callback_encryption_key)
+        Base64.decode64(Telephony.config.twilio.voice_callback_encryption_key)
       end
     end
   end

--- a/lib/telephony/twilio/programmable_voice_sender.rb
+++ b/lib/telephony/twilio/programmable_voice_sender.rb
@@ -6,7 +6,7 @@ module Telephony
           from: from_number,
           to: to,
           url: callback_url_for_message(message),
-          record: Telephony.config.twilio_record_voice,
+          record: Telephony.config.twilio.record_voice,
         )
       rescue ::Twilio::REST::RestError => e
         handle_twilio_rest_error(e)
@@ -17,7 +17,7 @@ module Telephony
       private
 
       def from_number
-        Telephony.config.twilio_numbers.sample
+        Telephony.config.twilio.numbers.sample
       end
 
       def callback_url_for_message(message)

--- a/lib/telephony/twilio/verify_client.rb
+++ b/lib/telephony/twilio/verify_client.rb
@@ -28,7 +28,7 @@ module Telephony
       def response
         @response ||= http_client.post do |request|
           request.url AUTHY_VERIFY_ENDPOINT
-          request.headers['X-Authy-API-Key'] = Telephony.config.twilio_verify_api_key
+          request.headers['X-Authy-API-Key'] = Telephony.config.twilio.verify_api_key
           request.body = request_body
         end
       end
@@ -94,7 +94,7 @@ module Telephony
       end
 
       def http_timeout
-        @http_timeout ||= Telephony.config.twilio_timeout.to_i
+        @http_timeout ||= Telephony.config.twilio.timeout.to_i
       end
     end
   end

--- a/spec/lib/pinpoint/longcode_sms_sender_spec.rb
+++ b/spec/lib/pinpoint/longcode_sms_sender_spec.rb
@@ -5,17 +5,18 @@ describe Telephony::Pinpoint::LongcodeSmsSender do
     it 'initializes a pinpoint client and uses that to send a message with a longcode' do
       expect(Aws::Pinpoint::Client).to receive(:new).
         with(
-          region: Telephony.config.pinpoint_region,
-          access_key_id: Telephony.config.pinpoint_access_key_id,
-          secret_access_key: Telephony.config.pinpoint_secret_access_key,
+          region: Telephony.config.pinpoint.sms.region,
+          access_key_id: Telephony.config.pinpoint.sms.access_key_id,
+          secret_access_key: Telephony.config.pinpoint.sms.secret_access_key,
         ).
         and_return(Pinpoint::MockClient.new)
-      expect(Telephony.config.pinpoint_longcode_pool).to receive(:sample).and_return('+12223334444')
+      expect(Telephony.config.pinpoint.sms.longcode_pool).to receive(:sample).
+        and_return('+12223334444')
 
       subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')
 
       expected_result = {
-        application_id: Telephony.config.pinpoint_application_id,
+        application_id: Telephony.config.pinpoint.sms.application_id,
         message_request: {
           addresses: {
             '+1 (123) 456-7890' => { channel_type: 'SMS' },

--- a/spec/lib/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/pinpoint/sms_sender_spec.rb
@@ -5,16 +5,16 @@ describe Telephony::Pinpoint::SmsSender do
     it 'initializes a pinpoint client and uses that to send a message with a shortcode' do
       expect(Aws::Pinpoint::Client).to receive(:new).
         with(
-          region: Telephony.config.pinpoint_region,
-          access_key_id: Telephony.config.pinpoint_access_key_id,
-          secret_access_key: Telephony.config.pinpoint_secret_access_key,
+          region: Telephony.config.pinpoint.sms.region,
+          access_key_id: Telephony.config.pinpoint.sms.access_key_id,
+          secret_access_key: Telephony.config.pinpoint.sms.secret_access_key,
         ).
         and_return(Pinpoint::MockClient.new)
 
       subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')
 
       expected_result = {
-        application_id: Telephony.config.pinpoint_application_id,
+        application_id: Telephony.config.pinpoint.sms.application_id,
         message_request: {
           addresses: {
             '+1 (123) 456-7890' => { channel_type: 'SMS' },

--- a/spec/lib/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/pinpoint/voice_sender_spec.rb
@@ -21,12 +21,12 @@ describe Telephony::Pinpoint::VoiceSender do
     before do
       allow(Aws::PinpointSMSVoice::Client).to receive(:new).
         with(
-          region: Telephony.config.pinpoint_region,
-          access_key_id: Telephony.config.pinpoint_access_key_id,
-          secret_access_key: Telephony.config.pinpoint_secret_access_key,
+          region: Telephony.config.pinpoint.voice.region,
+          access_key_id: Telephony.config.pinpoint.voice.access_key_id,
+          secret_access_key: Telephony.config.pinpoint.voice.secret_access_key,
         ).
         and_return(pinpoint_sms_voice_client)
-      allow(Telephony.config.pinpoint_longcode_pool).to receive(:sample).and_return(sending_phone)
+      allow(Telephony.config.pinpoint.voice.longcode_pool).to receive(:sample).and_return(sending_phone)
     end
 
     it 'initializes a pinpoint sms and voice client and uses that to send a message' do

--- a/spec/lib/twilio/programmable_sms_sender_spec.rb
+++ b/spec/lib/twilio/programmable_sms_sender_spec.rb
@@ -5,17 +5,17 @@ describe Telephony::Twilio::ProgrammableSmsSender do
     it 'initializes a twilio client and uses that to send a message' do
       client = instance_double(::Twilio::REST::Client)
       expect(::Twilio::REST::Client).to receive(:new).with(
-        Telephony.config.twilio_sid,
-        Telephony.config.twilio_auth_token,
+        Telephony.config.twilio.sid,
+        Telephony.config.twilio.auth_token,
         nil,
         nil,
-        instance_of(::Twilio::HTTP::Client)
+        instance_of(::Twilio::HTTP::Client),
       ).and_return(client)
 
       messages = double
       expect(client).to receive(:messages).and_return(messages)
       expect(messages).to receive(:create).with(
-        messaging_service_sid: Telephony.config.twilio_messaging_service_sid,
+        messaging_service_sid: Telephony.config.twilio.messaging_service_sid,
         to: '+1 (123) 456-7890',
         body: 'This is a test!',
       )

--- a/spec/lib/twilio/programmable_voice_message_spec.rb
+++ b/spec/lib/twilio/programmable_voice_message_spec.rb
@@ -37,7 +37,7 @@ describe Telephony::Twilio::ProgrammableVoiceMessage do
     it 'returns a url with the correct base url and a message that can be parsed from the params' do
       callback_url = subject.callback_url
 
-      expect(callback_url).to match(/^#{Telephony.config.twilio_voice_callback_base_url}/)
+      expect(callback_url).to match(/^#{Telephony.config.twilio.voice_callback_base_url}/)
 
       parsed_message = described_class.from_callback(callback_url)
 

--- a/spec/lib/twilio/programmable_voice_sender_spec.rb
+++ b/spec/lib/twilio/programmable_voice_sender_spec.rb
@@ -5,14 +5,14 @@ describe Telephony::Twilio::ProgrammableVoiceSender do
     it 'initializes a twilio client and uses that to place a call with a random number' do
       client = instance_double(::Twilio::REST::Client)
       expect(::Twilio::REST::Client).to receive(:new).with(
-        Telephony.config.twilio_sid,
-        Telephony.config.twilio_auth_token,
+        Telephony.config.twilio.sid,
+        Telephony.config.twilio.auth_token,
         nil,
         nil,
-        instance_of(::Twilio::HTTP::Client)
+        instance_of(::Twilio::HTTP::Client),
       ).and_return(client)
 
-      expect(Telephony.config.twilio_numbers).to receive(:sample).and_return('12223334444')
+      expect(Telephony.config.twilio.numbers).to receive(:sample).and_return('12223334444')
 
       calls = double
       expect(client).to receive(:calls).and_return(calls)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,20 +7,26 @@ Dir[File.dirname(__FILE__) + '/support/*.rb'].sort.each { |file| require file }
 
 # Setup some default configs
 Telephony.config do |c|
-  c.twilio_numbers = ['12223334444', '15556667777']
-  c.twilio_sid = 'fake-twilio-sid'
-  c.twilio_auth_token = 'fake-twilio-auth-token'
-  c.twilio_messaging_service_sid = 'fake-twilio-messaging-service-sid'
-  c.twilio_verify_api_key = 'fake-twilio-verify-api-key'
-  c.twilio_voice_callback_encryption_key = Base64.strict_encode64('0' * 32)
-  c.twilio_voice_callback_base_url = 'https://example.com/api/voice'
+  c.twilio.numbers = ['12223334444', '15556667777']
+  c.twilio.sid = 'fake-twilio-sid'
+  c.twilio.auth_token = 'fake-twilio-auth-token'
+  c.twilio.messaging_service_sid = 'fake-twilio-messaging-service-sid'
+  c.twilio.verify_api_key = 'fake-twilio-verify-api-key'
+  c.twilio.voice_callback_encryption_key = Base64.strict_encode64('0' * 32)
+  c.twilio.voice_callback_base_url = 'https://example.com/api/voice'
 
-  c.pinpoint_region = 'fake-pinpoint-region'
-  c.pinpoint_access_key_id = 'fake-pinpoint-access-key-id'
-  c.pinpoint_secret_access_key = 'fake-pinpoint-secret-access-key'
-  c.pinpoint_application_id = 'fake-pinpoint-application-id'
-  c.pinpoint_shortcode = '123456'
-  c.pinpoint_longcode_pool = ['+12223334444', '+15556667777']
+  c.pinpoint.sms.region = 'fake-pinpoint-region-sms'
+  c.pinpoint.sms.access_key_id = 'fake-pinpoint-access-key-id-sms'
+  c.pinpoint.sms.secret_access_key = 'fake-pinpoint-secret-access-key-sms'
+  c.pinpoint.sms.application_id = 'fake-pinpoint-application-id-sms'
+  c.pinpoint.sms.shortcode = '123456'
+  c.pinpoint.sms.longcode_pool = ['+12223334444', '+15556667777']
+
+  c.pinpoint.voice.region = 'fake-pinpoint-region-voice'
+  c.pinpoint.voice.access_key_id = 'fake-pinpoint-access-key-id-voice'
+  c.pinpoint.voice.secret_access_key = 'fake-pinpoint-secret-access-key-voice'
+  c.pinpoint.voice.application_id = 'fake-pinpoint-application-id-voice'
+  c.pinpoint.voice.longcode_pool = ['+12223334444', '+15556667777']
 end
 
 RSpec.configure do |config|

--- a/spec/support/pinpoint_mock_client.rb
+++ b/spec/support/pinpoint_mock_client.rb
@@ -19,7 +19,7 @@ module Pinpoint
     MessageResponseResult = Struct.new(:status_code, :delivery_status)
 
     def send_messages(request)
-      expect(request[:application_id]).to eq(Telephony.config.pinpoint_application_id)
+      expect(request[:application_id]).to eq(Telephony.config.pinpoint.sms.application_id)
 
       self.class.last_request = request
 

--- a/spec/support/shared_examples_for_pinpoint_sms.rb
+++ b/spec/support/shared_examples_for_pinpoint_sms.rb
@@ -7,9 +7,9 @@ shared_examples 'a pinpoint sms client' do
     before do
       allow(Aws::Pinpoint::Client).to receive(:new).
         with(
-          region: Telephony.config.pinpoint_region,
-          access_key_id: Telephony.config.pinpoint_access_key_id,
-          secret_access_key: Telephony.config.pinpoint_secret_access_key,
+          region: Telephony.config.pinpoint.sms.region,
+          access_key_id: Telephony.config.pinpoint.sms.access_key_id,
+          secret_access_key: Telephony.config.pinpoint.sms.secret_access_key,
         ).
         and_return(Pinpoint::MockClient.new)
 


### PR DESCRIPTION
**Why**: So we can setup SMS and voice in different regions with different numbers. This allows us to make use of the shared shortcode pool for SMS while having longcodes provisioned for voice.

Currently pinpoint does not allow you to use the shared shortcode pool if you have phone numbers registered w/i a region. Additionally, it does not let you make voice calls unless you do have numbers registered. The work around for making voice calls while also using the shared shortcode is to use on region for SMS, with no numbers registered, and a different region where numbers are registered for voice calls.