### PR TITLE
LG-1932 Add a Twilio Verify override flag

### DIFF
--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -6,6 +6,7 @@ module Telephony
     :auth_token,
     :messaging_service_sid,
     :record_voice,
+    :verify_override_for_intl_sms,
     :verify_api_key,
     :voice_callback_encryption_key,
     :voice_callback_base_url,
@@ -27,9 +28,14 @@ module Telephony
     attr_writer :adapter
     attr_reader :twilio, :pinpoint
 
+    # rubocop:disable Metrics/MethodLength
     def initialize
       @adapter = :twilio
-      @twilio = TwilioConfiguration.new(timeout: 5, record_voice: false)
+      @twilio = TwilioConfiguration.new(
+        timeout: 5,
+        record_voice: false,
+        verify_override_for_intl_sms: true,
+      )
       pinpoint_voice = PinpointVoiceConfiguration.new(
         region: 'us-west-2',
       )
@@ -38,6 +44,7 @@ module Telephony
       )
       @pinpoint = PinpointConfiguration.new(voice: pinpoint_voice, sms: pinpoint_sms)
     end
+    # rubocop:enable Metrics/MethodLength
 
     def adapter
       @adapter.to_sym

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -30,11 +30,15 @@ module Telephony
     def should_use_twilio_verify?
       return false unless channel == :sms
       return false if Telephony.config.adapter == :test
-      return false unless Telephony.config.adapter == :twilio ||
-                          Telephony.config.twilio.verify_override_for_intl_sms == true
+      return false unless twilio_enabled_or_override_set?
 
       destination_country = Phonelib.parse(recipient_phone).country
       !['US', 'CA', 'MX'].include?(destination_country)
+    end
+
+    def twilio_enabled_or_override_set?
+      Telephony.config.adapter == :twilio ||
+        Telephony.config.twilio.verify_override_for_intl_sms == true
     end
 
     # rubocop:disable all

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -28,11 +28,13 @@ module Telephony
     private
 
     def should_use_twilio_verify?
-      return false unless Telephony.config.adapter == :twilio
       return false unless channel == :sms
+      return false if Telephony.config.adapter == :test
+      return false unless Telephony.config.adapter == :twilio ||
+                          Telephony.config.twilio.verify_override_for_intl_sms == true
 
       destination_country = Phonelib.parse(recipient_phone).country
-      !%w[US CA MX].include?(destination_country)
+      !['US', 'CA', 'MX'].include?(destination_country)
     end
 
     # rubocop:disable all

--- a/spec/lib/otp_sender/pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/pinpoint_adapter_spec.rb
@@ -32,6 +32,40 @@ describe Telephony::OtpSender do
 
         subject.send_confirmation_otp
       end
+
+      context 'with Twilio verify override enabled' do
+        let(:to) { '+81543543643' }
+
+        before do
+          allow(Telephony.config.twilio).to receive(:verify_override_for_intl_sms).and_return(true)
+        end
+
+        it 'sends international SMS with Twilio Verify' do
+          verify_client = instance_double(Telephony::Twilio::VerifyClient)
+          expect(verify_client).to receive(:send).with(otp: otp, to: to)
+          expect(Telephony::Twilio::VerifyClient).to receive(:new).and_return(verify_client)
+
+          subject.send_authentication_otp
+        end
+      end
+
+      context 'with Twilio verify override disabled' do
+        let(:to) { '+81543543643' }
+
+        before do
+          allow(Telephony.config.twilio).to receive(:verify_override_for_intl_sms).and_return(false)
+        end
+
+        it 'does sends international SMS with Pinpoint' do
+          message = '123456 is your login.gov security code. Use this to continue signing in to your account. This code will expire in 5 minutes.'
+
+          adapter = instance_double(Telephony::Pinpoint::SmsSender)
+          expect(adapter).to receive(:send).with(message: message, to: to)
+          expect(Telephony::Pinpoint::SmsSender).to receive(:new).and_return(adapter)
+
+          subject.send_authentication_otp
+        end
+      end
     end
 
     context 'for voice' do


### PR DESCRIPTION
**Why**: So that we can use Twilio Verify for international SMS even if the Pinpoint adapter is in use.