### PR TITLE
LG-1955 Don't set the AWS credentials on init if they are nil

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity-telephony (0.0.9)
+    identity-telephony (0.0.10)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n
@@ -35,8 +35,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.208.0)
-    aws-sdk-core (3.66.0)
+    aws-partitions (1.217.0)
+    aws-sdk-core (3.68.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -146,7 +146,7 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    twilio-ruby (5.26.0)
+    twilio-ruby (5.27.0)
       faraday (~> 0.9)
       jwt (>= 1.5, <= 2.5)
       nokogiri (>= 1.6, < 2.0)

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -43,10 +43,10 @@ module Telephony
       private
 
       def pinpoint_client
-        @pinpoint_client ||= Aws::Pinpoint::Client.new(
-          region: Telephony.config.pinpoint.sms.region,
-          credentials: AwsCredentialBuilder.new(:sms).call,
-        )
+        credentials = AwsCredentialBuilder.new(:sms).call
+        args = { region: Telephony.config.pinpoint.sms.region }
+        args[:credentials] = credentials unless credentials.nil?
+        @pinpoint_client ||= Aws::Pinpoint::Client.new(args)
       end
 
       def raise_if_error(response)

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -23,10 +23,10 @@ module Telephony
       private
 
       def pinpoint_client
-        @pinpoint_client ||= Aws::PinpointSMSVoice::Client.new(
-          region: Telephony.config.pinpoint.voice.region,
-          credentials: AwsCredentialBuilder.new(:voice).call,
-        )
+        credentials = AwsCredentialBuilder.new(:voice).call
+        args = { region: Telephony.config.pinpoint.sms.region }
+        args[:credentials] = credentials unless credentials.nil?
+        @pinpoint_client ||= Aws::PinpointSMSVoice::Client.new(args)
       end
 
       def handle_pinpoint_error(err)

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -24,7 +24,7 @@ module Telephony
 
       def pinpoint_client
         credentials = AwsCredentialBuilder.new(:voice).call
-        args = { region: Telephony.config.pinpoint.sms.region }
+        args = { region: Telephony.config.pinpoint.voice.region }
         args[:credentials] = credentials unless credentials.nil?
         @pinpoint_client ||= Aws::PinpointSMSVoice::Client.new(args)
       end


### PR DESCRIPTION
**Why**: Because it errors out if the credentials are nil