### PR TITLE
LG-2133 Update the OTP messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity-telephony (0.0.11)
+    identity-telephony (0.0.12)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n
@@ -35,7 +35,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.217.0)
+    aws-partitions (1.220.0)
     aws-sdk-core (3.68.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
@@ -60,7 +60,7 @@ GEM
     erubi (1.8.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    faraday (0.15.4)
+    faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     hashdiff (1.0.0)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,10 +4,10 @@ en:
     account_reset_cancellation_notice: Your request to delete your login.gov account has been cancelled.
     account_reset_notice: 'You''ve requested to delete your login.gov account. Your request will be processed in 24 hours. If you don’t want to delete your account, please cancel: %{cancel_link}'
     authentication_otp:
-      sms: "%{code} is your login.gov security code. Use this to continue signing in to your account. This code will expire in %{expiration} minutes."
+      sms: "Enter %{code} in login.gov to continue signing. This security code will expire in %{expiration} minutes."
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     confirmation_otp:
-      sms: "%{code} is your login.gov confirmation code. Use this to confirm your phone number. This code will expire in %{expiration} minutes."
+      sms: "Enter %{code} in login.gov to confirm your phone number. This security code will expire in %{expiration} minutes."
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     doc_auth_link: 'You''ve requested to verify your identity on a mobile phone.  Please take a photo of your state issued ID: %{link}'
     error:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,10 +4,10 @@ en:
     account_reset_cancellation_notice: Your request to delete your login.gov account has been cancelled.
     account_reset_notice: 'You''ve requested to delete your login.gov account. Your request will be processed in 24 hours. If you don’t want to delete your account, please cancel: %{cancel_link}'
     authentication_otp:
-      sms: "Enter %{code} in login.gov to continue signing. This security code will expire in %{expiration} minutes."
+      sms: Enter %{code} in login.gov to continue signing. This security code will expire in %{expiration} minutes.
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     confirmation_otp:
-      sms: "Enter %{code} in login.gov to confirm your phone number. This security code will expire in %{expiration} minutes."
+      sms: Enter %{code} in login.gov to confirm your phone number. This security code will expire in %{expiration} minutes.
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     doc_auth_link: 'You''ve requested to verify your identity on a mobile phone.  Please take a photo of your state issued ID: %{link}'
     error:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,10 +4,10 @@ es:
     account_reset_cancellation_notice: Votre demande de suppression de votre compte login.gov a été annulée.
     account_reset_notice: Su solicitud para eliminar su cuenta de login.gov ha sido cancelada.
     authentication_otp:
-      sms: "%{code} es tu código de seguridad de login.gov. Use esto para continuar ingresando a su cuenta. Este código caducará en %{expiration} minutos."
+      sms: "Ingrese %{code} en login.gov para continuar iniciando sesión. Este código de seguridad caducará en %{expiration} minutos."
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     confirmation_otp:
-      sms: "%{code} es tu código de confirmación de login.gov. Use esto para confirmar su número de teléfono. Este código caducará en %{expiration} minutos."
+      sms: "Ingrese %{code} en login.gov para confirmar su número de teléfono. Este código de seguridad caducará en %{expiration} minutos."
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     doc_auth_link: 'Has solicitado verificar tu identidad en un teléfono móvil. Por favor, tome una foto de la identificación emitida por su estado: %{link}'
     error:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,10 +4,10 @@ es:
     account_reset_cancellation_notice: Votre demande de suppression de votre compte login.gov a été annulée.
     account_reset_notice: Su solicitud para eliminar su cuenta de login.gov ha sido cancelada.
     authentication_otp:
-      sms: "Ingrese %{code} en login.gov para continuar iniciando sesión. Este código de seguridad caducará en %{expiration} minutos."
+      sms: Ingrese %{code} en login.gov para continuar iniciando sesión. Este código de seguridad caducará en %{expiration} minutos.
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     confirmation_otp:
-      sms: "Ingrese %{code} en login.gov para confirmar su número de teléfono. Este código de seguridad caducará en %{expiration} minutos."
+      sms: Ingrese %{code} en login.gov para confirmar su número de teléfono. Este código de seguridad caducará en %{expiration} minutos.
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     doc_auth_link: 'Has solicitado verificar tu identidad en un teléfono móvil. Por favor, tome una foto de la identificación emitida por su estado: %{link}'
     error:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,10 +4,10 @@ fr:
     account_reset_cancellation_notice: Votre demande de suppression de votre compte login.gov a été annulée.
     account_reset_notice: 'Vous avez demandé à supprimer votre compte login.gov. Votre demande sera être traité en 24 heures. Si vous ne souhaitez pas supprimer votre compte, veuillez cancel: %{cancel_link}'
     authentication_otp:
-      sms: "Entrez %{code} dans login.gov pour continuer à vous connecter à votre compte. Ce code de sécurité expirera dans %{expiration} minutes."
+      sms: Entrez %{code} dans login.gov pour continuer à vous connecter à votre compte. Ce code de sécurité expirera dans %{expiration} minutes.
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     confirmation_otp:
-      sms: "Entrez %{code} dans login.gov pour confirmer votre numéro de téléphone. Ce code de sécurité expirera dans %{expiration} minutes."
+      sms: Entrez %{code} dans login.gov pour confirmer votre numéro de téléphone. Ce code de sécurité expirera dans %{expiration} minutes.
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     doc_auth_link: 'Vous avez demandé à vérifier votre identité sur un téléphone mobile. S''il vous plaît prendre une photo de votre identité émise par l''état: %{link}'
     error:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,10 +4,10 @@ fr:
     account_reset_cancellation_notice: Votre demande de suppression de votre compte login.gov a été annulée.
     account_reset_notice: 'Vous avez demandé à supprimer votre compte login.gov. Votre demande sera être traité en 24 heures. Si vous ne souhaitez pas supprimer votre compte, veuillez cancel: %{cancel_link}'
     authentication_otp:
-      sms: "%{code} est votre code de sécurité login.gov. Utilisez-le pour continuer à vous connecter à votre compte. Ce code expirera dans %{expiration} minutes."
+      sms: "Entrez %{code} dans login.gov pour continuer la signature. Ce code de sécurité expirera dans %{expiration} minutes."
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     confirmation_otp:
-      sms: "%{code} est votre code de confirmation login.gov. Utilisez-le pour confirmer votre numéro de téléphone. Ce code expirera dans %{expiration} minutes."
+      sms: "Entrez %{code} dans login.gov pour confirmer votre numéro de téléphone. Ce code de sécurité expirera dans %{expiration} minutes."
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     doc_auth_link: 'Vous avez demandé à vérifier votre identité sur un téléphone mobile. S''il vous plaît prendre une photo de votre identité émise par l''état: %{link}'
     error:

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.0.12'.freeze
+  VERSION = '0.0.13'.freeze
 end

--- a/spec/lib/otp_sender/longcode_pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/longcode_pinpoint_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Pinpoint SMS using the longcode sender' do
-        message = '123456 is your login.gov security code. Use this to continue signing in to your account. This code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Pinpoint::LongcodeSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -24,7 +24,7 @@ describe Telephony::OtpSender do
       end
 
       it 'sends a confirmation OTP with Pinpoint SMS using the longcode sender' do
-        message = '123456 is your login.gov confirmation code. Use this to confirm your phone number. This code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to confirm your phone number. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Pinpoint::LongcodeSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)

--- a/spec/lib/otp_sender/pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/pinpoint_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Pinpoint SMS' do
-        message = '123456 is your login.gov security code. Use this to continue signing in to your account. This code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -24,7 +24,7 @@ describe Telephony::OtpSender do
       end
 
       it 'sends a confirmation OTP with Pinpoint SMS' do
-        message = '123456 is your login.gov confirmation code. Use this to confirm your phone number. This code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to confirm your phone number. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -57,7 +57,7 @@ describe Telephony::OtpSender do
         end
 
         it 'does sends international SMS with Pinpoint' do
-          message = '123456 is your login.gov security code. Use this to continue signing in to your account. This code will expire in 5 minutes.'
+          message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
 
           adapter = instance_double(Telephony::Pinpoint::SmsSender)
           expect(adapter).to receive(:send).with(message: message, to: to)

--- a/spec/lib/otp_sender/twilio_adapter_spec.rb
+++ b/spec/lib/otp_sender/twilio_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Twilio Programmable SMS' do
-        message = '123456 is your login.gov security code. Use this to continue signing in to your account. This code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Twilio::ProgrammableSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -24,7 +24,7 @@ describe Telephony::OtpSender do
       end
 
       it 'sends a confirmation OTP with Twilio Programmable SMS' do
-        message = '123456 is your login.gov confirmation code. Use this to confirm your phone number. This code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to confirm your phone number. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Twilio::ProgrammableSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)


### PR DESCRIPTION
**Why**: The previous message caused the number to be read along with the phone number by a11y tools on phones. This commit adds some english words between the number and the phone number to make the barrier obvious.