### PR TITLE
Fix authentication OTP translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
     account_reset_cancellation_notice: Your request to delete your login.gov account has been cancelled.
     account_reset_notice: 'You''ve requested to delete your login.gov account. Your request will be processed in 24 hours. If you don’t want to delete your account, please cancel: %{cancel_link}'
     authentication_otp:
-      sms: Enter %{code} in login.gov to continue signing. This security code will expire in %{expiration} minutes.
+      sms: Enter %{code} in login.gov to continue signing in to your account. This security code will expire in %{expiration} minutes.
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     confirmation_otp:
       sms: Enter %{code} in login.gov to confirm your phone number. This security code will expire in %{expiration} minutes.

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.0.13'.freeze
+  VERSION = '0.0.14'.freeze
 end

--- a/spec/lib/otp_sender/longcode_pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/longcode_pinpoint_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Pinpoint SMS using the longcode sender' do
-        message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to continue signing in to your account. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Pinpoint::LongcodeSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)

--- a/spec/lib/otp_sender/pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/pinpoint_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Pinpoint SMS' do
-        message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to continue signing in to your account. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -57,7 +57,7 @@ describe Telephony::OtpSender do
         end
 
         it 'does sends international SMS with Pinpoint' do
-          message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
+          message = 'Enter 123456 in login.gov to continue signing in to your account. This security code will expire in 5 minutes.'
 
           adapter = instance_double(Telephony::Pinpoint::SmsSender)
           expect(adapter).to receive(:send).with(message: message, to: to)

--- a/spec/lib/otp_sender/twilio_adapter_spec.rb
+++ b/spec/lib/otp_sender/twilio_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Twilio Programmable SMS' do
-        message = 'Enter 123456 in login.gov to continue signing. This security code will expire in 5 minutes.'
+        message = 'Enter 123456 in login.gov to continue signing in to your account. This security code will expire in 5 minutes.'
 
         adapter = instance_double(Telephony::Twilio::ProgrammableSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)


### PR DESCRIPTION
**Why**: So that it does not have a typo.