### PR TITLE
Limit Pinpoint client to 1 retry

### DIFF
--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -38,7 +38,7 @@ module Telephony
 
       def pinpoint_client
         credentials = AwsCredentialBuilder.new(:sms).call
-        args = { region: Telephony.config.pinpoint.sms.region }
+        args = { region: Telephony.config.pinpoint.sms.region, retry_limit: 1 }
         args[:credentials] = credentials unless credentials.nil?
         @pinpoint_client ||= Aws::Pinpoint::Client.new(args)
       end

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -24,7 +24,7 @@ module Telephony
 
       def pinpoint_client
         credentials = AwsCredentialBuilder.new(:voice).call
-        args = { region: Telephony.config.pinpoint.voice.region }
+        args = { region: Telephony.config.pinpoint.voice.region, retry_limit: 1 }
         args[:credentials] = credentials unless credentials.nil?
         @pinpoint_client ||= Aws::PinpointSMSVoice::Client.new(args)
       end

--- a/spec/lib/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/pinpoint/sms_sender_spec.rb
@@ -13,6 +13,7 @@ describe Telephony::Pinpoint::SmsSender do
         with(
           region: Telephony.config.pinpoint.sms.region,
           credentials: credentials,
+          retry_limit: 1,
         ).
         and_return(Pinpoint::MockClient.new)
 

--- a/spec/lib/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/pinpoint/voice_sender_spec.rb
@@ -27,8 +27,10 @@ describe Telephony::Pinpoint::VoiceSender do
       allow(credential_builder).to receive(:call).and_return(credentials)
       allow(Aws::PinpointSMSVoice::Client).to receive(:new).
         with(
+
           region: Telephony.config.pinpoint.voice.region,
           credentials: credentials,
+          retry_limit: 1,
         ).
         and_return(pinpoint_sms_voice_client)
       allow(Telephony.config.pinpoint.voice.longcode_pool).to receive(:sample).and_return(sending_phone)

--- a/spec/lib/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/pinpoint/voice_sender_spec.rb
@@ -27,7 +27,6 @@ describe Telephony::Pinpoint::VoiceSender do
       allow(credential_builder).to receive(:call).and_return(credentials)
       allow(Aws::PinpointSMSVoice::Client).to receive(:new).
         with(
-
           region: Telephony.config.pinpoint.voice.region,
           credentials: credentials,
           retry_limit: 1,

--- a/spec/support/shared_examples_for_pinpoint_sms.rb
+++ b/spec/support/shared_examples_for_pinpoint_sms.rb
@@ -15,6 +15,7 @@ shared_examples 'a pinpoint sms client' do
         with(
           region: Telephony.config.pinpoint.sms.region,
           credentials: credentials,
+          retry_limit: 1,
         ).
         and_return(Pinpoint::MockClient.new)
 


### PR DESCRIPTION
**Why**: We have had issues with the IdP attempting 3 retries and timing out. This commit limits Pinpoint to 1 retry which should fit within the IdP's timeout window.