### PR TITLE
Change SMS content to autofill properly (LG-3691)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,10 +4,10 @@ en:
     account_reset_cancellation_notice: Your request to delete your login.gov account has been cancelled.
     account_reset_notice: As requested, your login.gov account will be deleted in 24 hours. Don't want to delete your account? Sign in to your login.gov account to cancel.
     authentication_otp:
-      sms: Enter %{code} in login.gov to continue signing in to your account. This security code will expire in %{expiration} minutes.
+      sms: 'Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don''t share this code with anyone.'
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     confirmation_otp:
-      sms: Enter %{code} in login.gov to confirm your phone number. This security code will expire in %{expiration} minutes.
+      sms: 'Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don''t share this code with anyone.'
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     doc_auth_link: "%{link} You've requested to verify your identity on a mobile phone.  Please take a photo of your state issued ID."
     error:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,10 +4,10 @@ es:
     account_reset_cancellation_notice: Su solicitud para eliminar su cuenta de login.gov ha sido cancelada.
     account_reset_notice: Según lo solicitado, su cuenta login.gov se eliminará en 24 horas. ¿No quieres eliminar tu cuenta? Inicie sesión en su cuenta login.gov para cancelar.
     authentication_otp:
-      sms: Ingrese %{code} en login.gov para continuar iniciando sesión. Este código de seguridad caducará en %{expiration} minutos.
+      sms: 'Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.'
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     confirmation_otp:
-      sms: Ingrese %{code} en login.gov para confirmar su número de teléfono. Este código de seguridad caducará en %{expiration} minutos.
+      sms: 'Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.'
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     doc_auth_link: "%{link} Has solicitado verificar tu identidad en un teléfono móvil. Por favor, tome una foto de la identificación emitida por su estado"
     error:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,10 +4,10 @@ fr:
     account_reset_cancellation_notice: Votre demande de suppression de votre compte login.gov a été annulée.
     account_reset_notice: Comme demandé, votre compte login.gov sera supprimé dans les 24 heures. Vous ne voulez pas supprimer votre compte? Connectez-vous à votre compte login.gov pour le annuler.
     authentication_otp:
-      sms: Entrez %{code} dans login.gov pour continuer à vous connecter à votre compte. Ce code de sécurité expirera dans %{expiration} minutes.
+      sms: 'Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.'
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     confirmation_otp:
-      sms: Entrez %{code} dans login.gov pour confirmer votre numéro de téléphone. Ce code de sécurité expirera dans %{expiration} minutes.
+      sms: 'Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.'
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     doc_auth_link: "%{link} Vous avez demandé à vérifier votre identité sur un téléphone mobile. S'il vous plaît prendre une photo de votre identité émise par l'état"
     error:

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.1.5'.freeze
+  VERSION = '0.1.6'.freeze
 end

--- a/spec/lib/otp_sender/pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/pinpoint_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Pinpoint SMS' do
-        message = 'Enter 123456 in login.gov to continue signing in to your account. This security code will expire in 5 minutes.'
+        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone."
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -24,7 +24,7 @@ describe Telephony::OtpSender do
       end
 
       it 'sends a confirmation OTP with Pinpoint SMS' do
-        message = 'Enter 123456 in login.gov to confirm your phone number. This security code will expire in 5 minutes.'
+        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone."
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)

--- a/spec/lib/otp_sender/twilio_adapter_spec.rb
+++ b/spec/lib/otp_sender/twilio_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Twilio Programmable SMS' do
-        message = 'Enter 123456 in login.gov to continue signing in to your account. This security code will expire in 5 minutes.'
+        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone."
 
         adapter = instance_double(Telephony::Twilio::ProgrammableSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -24,7 +24,7 @@ describe Telephony::OtpSender do
       end
 
       it 'sends a confirmation OTP with Twilio Programmable SMS' do
-        message = 'Enter 123456 in login.gov to confirm your phone number. This security code will expire in 5 minutes.'
+        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone."
 
         adapter = instance_double(Telephony::Twilio::ProgrammableSmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)


### PR DESCRIPTION
Updates content sent for SMS. It was also decided that the authentication and confirmation messages will be the same, so they've been consolidated. I don't think it's worth deduplicating the YAML at this point with how translation keys are dynamically built.

All translations were tested in my sandbox and do cause the autofill suggestion to show up.