### PR TITLE
Pinpoint OTP timeout error (LG-3925)

### DIFF
--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -132,6 +132,7 @@ module Telephony
           extra: extra.merge(
             failover: true,
             region: region,
+            channel: 'sms',
           ),
         )
         Telephony.config.logger.warn(response.to_h.to_json)

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -91,6 +91,7 @@ module Telephony
           extra: extra.merge(
             failover: true,
             region: region,
+            channel: 'voice',
           ),
         )
         Telephony.config.logger.warn(response.to_h.to_json)

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.1.7'.freeze
+  VERSION = '0.1.8'.freeze
 end

--- a/spec/lib/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/pinpoint/sms_sender_spec.rb
@@ -1,5 +1,7 @@
 describe Telephony::Pinpoint::SmsSender do
   subject(:sms_sender) { described_class.new }
+  let(:sms_config) { Telephony.config.pinpoint.sms_configs.first }
+  let(:mock_client) { Pinpoint::MockClient.new(sms_config) }
 
   # Monkeypatch library class so we can use it for argument matching
   class Aws::Credentials
@@ -10,14 +12,12 @@ describe Telephony::Pinpoint::SmsSender do
   end
 
   before do
-    sms_config = Telephony.config.pinpoint.sms_configs.first
-
     expect(sms_sender).to receive(:build_client)
       .with(
         region: sms_config.region,
         credentials: Aws::Credentials.new(sms_config.access_key_id, sms_config.secret_access_key),
         retry_limit: 0,
-      ).and_return(Pinpoint::MockClient.new(sms_config))
+      ).and_return(mock_client)
   end
 
   describe 'error handling' do
@@ -133,6 +133,19 @@ describe Telephony::Pinpoint::SmsSender do
         expect(response.extra[:request_id]).to eq('fake-message-request-id')
       end
     end
+
+    context 'when a timeout exception is raised' do
+      let(:raised_error_message) { 'Seahorse::Client::NetworkingError: Net::ReadTimeout' }
+
+      it 'handles the exception' do
+        expect(mock_client).to receive(:send_messages).and_raise(Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new))
+        response = subject.send(message: 'hello!', to: '+11234567890')
+        expect(response.success?).to eq(false)
+        expect(response.error).to eq(Telephony::TelephonyError.new(raised_error_message))
+        expect(response.extra[:delivery_status]).to eq nil
+        expect(response.extra[:request_id]).to eq nil
+      end
+    end
   end
 
   describe '#send' do
@@ -162,6 +175,9 @@ describe Telephony::Pinpoint::SmsSender do
     end
 
     context 'with multiple sms configs' do
+      let(:backup_sms_config) { Telephony.config.pinpoint.sms_configs.last }
+      let(:backup_mock_client) { Pinpoint::MockClient.new(backup_sms_config) }
+
       before do
         Telephony.config.pinpoint.add_sms_config do |sms|
           sms.region = 'backup-sms-region'
@@ -170,14 +186,12 @@ describe Telephony::Pinpoint::SmsSender do
           sms.application_id = 'backup-sms-application-id'
         end
 
-        backup_sms_config = Telephony.config.pinpoint.sms_configs.last
-
         expect(sms_sender).to receive(:build_client)
           .with(
             region: backup_sms_config.region,
             credentials: Aws::Credentials.new(backup_sms_config.access_key_id, backup_sms_config.secret_access_key),
             retry_limit: 0,
-          ).and_return(Pinpoint::MockClient.new(backup_sms_config))
+          ).and_return(backup_mock_client)
       end
 
       context 'when the first config succeeds' do
@@ -201,6 +215,19 @@ describe Telephony::Pinpoint::SmsSender do
           response = subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')
 
           expect(response.success?).to eq(false)
+        end
+      end
+
+      context 'when the first config raises a timeout exception' do
+        let(:raised_error_message) { 'Seahorse::Client::NetworkingError: Net::ReadTimeout' }
+
+        it 'logs a warning for each failure and tries the other configs' do
+          expect(sms_sender.client_configs.first.client).to receive(:send_messages).and_raise(Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new)).once
+          expect(sms_sender.client_configs.last.client).to receive(:send_messages).and_raise(Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new)).once
+
+          response = subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')
+          expect(response.success?).to eq(false)
+          expect(response.error).to eq(Telephony::TelephonyError.new(raised_error_message))
         end
       end
     end

--- a/spec/lib/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/pinpoint/voice_sender_spec.rb
@@ -135,6 +135,21 @@ describe Telephony::Pinpoint::VoiceSender do
       end
     end
 
+    context 'when pinpoint raises a timeout exception' do
+      it 'rescues the exception and returns an error' do
+        exception = Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new)
+        expect(voice_sender.client_configs.first.client).
+          to receive(:send_voice_message).and_raise(exception)
+
+        response = voice_sender.send(message: message, to: recipient_phone)
+
+        error_message = 'Seahorse::Client::NetworkingError: Net::ReadTimeout'
+
+        expect(response.success?).to eq(false)
+        expect(response.error).to eq(Telephony::TelephonyError.new(error_message))
+      end
+    end
+
     context 'with multiple voice configs' do
       before do
         Telephony.config.pinpoint.add_voice_config do |voice|


### PR DESCRIPTION
To avoid raising exceptions in the IDP during OTP requests, we need to rescue `Seahorse::Client::NetworkingError` during calls to Pinpoint for SMS/Voice.

Voice already had a rescue case, so the SMS rescue was modeled after it. The multiple configs should be tried even if one of them raises an exception since the rescues are implemented within the loop.