### PR TITLE
Update sample phone_info error case ordering to behave as expected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity-telephony (0.1.10)
+    identity-telephony (0.1.11)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n
@@ -32,13 +32,13 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.416.0)
-    aws-sdk-core (3.111.0)
+    aws-partitions (1.417.0)
+    aws-sdk-core (3.111.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-pinpoint (1.47.0)
+    aws-sdk-pinpoint (1.48.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-pinpointsmsvoice (1.21.0)

--- a/lib/telephony/test/sms_sender.rb
+++ b/lib/telephony/test/sms_sender.rb
@@ -16,15 +16,15 @@ module Telephony
       def phone_info(phone_number)
         error = ErrorSimulator.new.error_for_number(phone_number)
         case error
-        when TelephonyError
-          PhoneNumberInfo.new(
-            type: :unknown,
-            error: error
-          )
         when InvalidCallingAreaError
           PhoneNumberInfo.new(
             type: :voip,
             carrier: "Test VOIP Carrier"
+          )
+        when TelephonyError
+          PhoneNumberInfo.new(
+            type: :unknown,
+            error: error
           )
         else
           PhoneNumberInfo.new(

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.1.10'.freeze
+  VERSION = '0.1.11'.freeze
 end

--- a/spec/lib/test/sms_sender_spec.rb
+++ b/spec/lib/test/sms_sender_spec.rb
@@ -59,7 +59,16 @@ describe Telephony::Test::SmsSender do
       end
     end
 
-    context 'with a phone number that generates errors' do
+    context 'generating a voip phone number' do
+      let(:phone_number) { '+12255552000' }
+      it 'has an error response' do
+        expect(phone_info.type).to eq(:voip)
+        expect(phone_info.carrier).to eq('Test VOIP Carrier')
+        expect(phone_info.error).to be_nil
+      end
+    end
+
+    context 'generating an error response' do
       let(:phone_number) { '+12255551000' }
       it 'has an error response' do
         expect(phone_info.type).to eq(:unknown)


### PR DESCRIPTION
`InvalidCallingAreaError` is a kind of `TelephonyError` so this didn't give the full range of error results I was hoping for.

This PR fixes that, adds test coverage