### PR TITLE
capture AWS STS timeout errors (LG-4220)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    identity-telephony (0.1.11)
+    identity-telephony (0.1.12)
       aws-sdk-pinpoint
       aws-sdk-pinpointsmsvoice
       i18n
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.417.0)
-    aws-sdk-core (3.111.2)
+    aws-partitions (1.429.0)
+    aws-sdk-core (3.112.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)

--- a/lib/telephony/pinpoint/aws_credential_builder.rb
+++ b/lib/telephony/pinpoint/aws_credential_builder.rb
@@ -25,6 +25,11 @@ module Telephony
           external_id: config.credential_external_id,
           client: Aws::STS::Client.new(region: config.region),
         )
+
+        # STS makes an HTTP call that can fail
+      rescue Seahorse::Client::NetworkingError => e
+        notify_role_failure(error: e, region: config.region)
+        nil
       end
 
       def build_access_key_credential
@@ -32,6 +37,12 @@ module Telephony
           config.access_key_id,
           config.secret_access_key,
         )
+      end
+
+
+      def notify_role_failure(error:, region:)
+        error_log = { error: error, region: region }
+        Telephony.config.logger.warn(error_log.to_json)
       end
     end
   end

--- a/lib/telephony/pinpoint/aws_credential_builder.rb
+++ b/lib/telephony/pinpoint/aws_credential_builder.rb
@@ -26,7 +26,7 @@ module Telephony
           client: Aws::STS::Client.new(region: config.region),
         )
 
-        # STS makes an HTTP call that can fail
+      # STS makes an HTTP call that can fail
       rescue Seahorse::Client::NetworkingError => e
         notify_role_failure(error: e, region: config.region)
         nil

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -4,8 +4,6 @@ require 'time'
 module Telephony
   module Pinpoint
     class SmsSender
-      ClientConfig = Struct.new(:client, :config)
-
       ERROR_HASH = {
         'DUPLICATE' => DuplicateEndpointError,
         'OPT_OUT' => OptOutError,
@@ -19,13 +17,15 @@ module Telephony
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
       # @return [Response]
       def send(message:, to:)
-        return handle_config_failure if client_configs.empty?
+        return handle_config_failure if Telephony.config.pinpoint.sms_configs.empty?
 
         response = nil
-        client_configs.each do |client_config|
+        Telephony.config.pinpoint.sms_configs.each do |sms_config|
           start = Time.now
-          pinpoint_response = client_config.client.send_messages(
-            application_id: client_config.config.application_id,
+          client = build_client(sms_config)
+          next if client.nil?
+          pinpoint_response = client.send_messages(
+            application_id: sms_config.application_id,
             message_request: {
               addresses: {
                 to => {
@@ -36,7 +36,7 @@ module Telephony
                 sms_message: {
                   body: message,
                   message_type: 'TRANSACTIONAL',
-                  origination_number: client_config.config.shortcode,
+                  origination_number: sms_config.shortcode,
                 },
               },
             },
@@ -46,7 +46,7 @@ module Telephony
           return response if response.success?
           notify_pinpoint_failover(
             error: response.error,
-            region: client_config.config.region,
+            region: sms_config.region,
             extra: response.extra,
           )
         rescue Seahorse::Client::NetworkingError => e
@@ -54,31 +54,34 @@ module Telephony
           response = handle_pinpoint_error(e)
           notify_pinpoint_failover(
             error: e,
-            region: client_config.config.region,
+            region: sms_config.region,
             extra: {
               duration_ms: Util.duration_ms(start: start, finish: finish),
             },
           )
         end
-        response
+        response || handle_config_failure
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
 
-
       def phone_info(phone_number)
+        return handle_config_failure if Telephony.config.pinpoint.sms_configs.empty?
+
         response = nil
         error = nil
 
-        client_configs.each do |client_config|
+        Telephony.config.pinpoint.sms_configs.each do |sms_config|
           error = nil
-          response = client_config.client.phone_number_validate(
+          client = build_client(sms_config)
+          next if client.nil?
+          response = client.phone_number_validate(
             number_validate_request: { phone_number: phone_number }
           )
           break if response
         rescue Seahorse::Client::NetworkingError => error
           notify_pinpoint_failover(
             error: error,
-            region: client_config.config.region,
+            region: sms_config.region,
             extra: {},
           )
         end
@@ -94,6 +97,8 @@ module Telephony
           :unknown
         end
 
+        error ||= unknown_failure_error if !response
+
         PhoneNumberInfo.new(
           type: type,
           carrier: response&.number_validate_response&.carrier,
@@ -102,25 +107,16 @@ module Telephony
       end
 
       # @api private
-      # An array of (client, config) pairs
-      # @return [Array<ClientConfig>]
-      def client_configs
-        @client_configs ||= Telephony.config.pinpoint.sms_configs.map do |sms_config|
-          credentials = AwsCredentialBuilder.new(sms_config).call
-          next if credentials.nil?
-
-          args = { region: sms_config.region, retry_limit: 0, credentials: credentials }
-
-          ClientConfig.new(
-            build_client(args),
-            sms_config,
-          )
-        end.compact
-      end
-
-      # @api private
-      def build_client(args)
-        Aws::Pinpoint::Client.new(args)
+      # @param [PinpointSmsConfig] sms_config
+      # @return [nil, Aws::Pinpoint::Client]
+      def build_client(sms_config)
+        credentials = AwsCredentialBuilder.new(sms_config).call
+        return if credentials.nil?
+        Aws::Pinpoint::Client.new(
+          region: sms_config.region,
+          retry_limit: 0,
+          credentials: credentials,
+        )
       end
 
       private
@@ -182,7 +178,7 @@ module Telephony
       def handle_config_failure
         response = Response.new(
           success: false,
-          error: UnknownFailureError.new('Failed to load AWS config'),
+          error: unknown_failure_error,
           extra: {
             channel: 'sms',
           },
@@ -191,6 +187,10 @@ module Telephony
         Telephony.config.logger.warn(response.to_h.to_json)
 
         response
+      end
+
+      def unknown_failure_error
+        UnknownFailureError.new('Failed to load AWS config')
       end
     end
   end

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -4,18 +4,18 @@ require 'telephony/util'
 module Telephony
   module Pinpoint
     class VoiceSender
-      ClientConfig = Struct.new(:client, :config)
-
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
       def send(message:, to:)
-        return handle_config_failure if client_configs.empty?
+        return handle_config_failure if Telephony.config.pinpoint.voice_configs.empty?
 
         language_code, voice_id = language_code_and_voice_id
 
         last_error = nil
-        client_configs.each do |client_config|
+        Telephony.config.pinpoint.voice_configs.each do |voice_config|
           start = Time.now
-          response = client_config.client.send_voice_message(
+          client = build_client(voice_config)
+          next if client.nil?
+          response = client.send_voice_message(
             content: {
               plain_text_message: {
                 text: message,
@@ -24,7 +24,7 @@ module Telephony
               },
             },
             destination_phone_number: to,
-            origination_phone_number: client_config.config.longcode_pool.sample,
+            origination_phone_number: voice_config.longcode_pool.sample,
           )
           finish = Time.now
           return Response.new(
@@ -40,32 +40,30 @@ module Telephony
           last_error = handle_pinpoint_error(e)
           notify_pinpoint_failover(
             error: e,
-            region: client_config.config.region,
+            region: voice_config.region,
             extra: {
               message_id: response&.message_id,
               duration_ms: Util.duration_ms(start: start, finish: finish),
             },
           )
         end
-        last_error
+
+        last_error || handle_config_failure
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
 
       # @api private
-      # An array of (client, config) pairs
-      # @return [Array<ClientConfig>]
-      def client_configs
-        @client_configs ||= Telephony.config.pinpoint.voice_configs.map do |voice_config|
-          credentials = AwsCredentialBuilder.new(voice_config).call
-          next if credentials.nil?
+      # @param [PinpointVoiceConfiguration] voice_config
+      # @return [nil, Aws::PinpointSMSVoice::Client]
+      def build_client(voice_config)
+        credentials = AwsCredentialBuilder.new(voice_config).call
+        return if credentials.nil?
 
-          args = { region: voice_config.region, retry_limit: 0, credentials: credentials }
-
-          ClientConfig.new(
-            Aws::PinpointSMSVoice::Client.new(args),
-            voice_config,
-          )
-        end.compact
+        Aws::PinpointSMSVoice::Client.new(
+          region: voice_config.region,
+          retry_limit: 0,
+          credentials: credentials,
+        )
       end
 
       private

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.1.11'.freeze
+  VERSION = '0.1.12'.freeze
 end

--- a/spec/lib/pinpoint/aws_credential_builder_spec.rb
+++ b/spec/lib/pinpoint/aws_credential_builder_spec.rb
@@ -37,6 +37,15 @@ describe Telephony::Pinpoint::AwsCredentialBuilder do
 
       expect(result).to eq(expected_credential)
     end
+
+    it 'returns nil if STS raises a Seahorse::Client::NetworkingError' do
+      expected_credential = instance_double(Aws::AssumeRoleCredentials)
+      expect(Aws::STS::Client).to receive(:new).and_raise(Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new))
+      expect(Telephony.config.logger).to receive(:warn)
+
+      result = credential_builder.call
+      expect(result).to eq(nil)
+    end
   end
 
   context 'with aws credentials in the config' do

--- a/spec/lib/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/pinpoint/voice_sender_spec.rb
@@ -204,5 +204,18 @@ describe Telephony::Pinpoint::VoiceSender do
         end
       end
     end
+
+    context 'when all voice configs fail to build' do
+      let(:raised_error_message) { 'Failed to load AWS config' }
+
+      it 'logs a warning and returns an error' do
+        expect(voice_sender).to receive(:client_configs).and_return([])
+        expect(Telephony.config.logger).to receive(:warn)
+
+        response = subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')
+        expect(response.success?).to eq(false)
+        expect(response.error).to eq(Telephony::UnknownFailureError.new(raised_error_message))
+      end
+    end
   end
 end

--- a/spec/lib/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/pinpoint/voice_sender_spec.rb
@@ -1,11 +1,27 @@
 describe Telephony::Pinpoint::VoiceSender do
   subject(:voice_sender) { described_class.new }
 
+  let(:pinpoint_client) { Aws::PinpointSMSVoice::Client.new(stub_responses: true) }
+  let(:voice_config) { Telephony.config.pinpoint.voice_configs.first }
+
+  let(:backup_pinpoint_client) { Aws::PinpointSMSVoice::Client.new(stub_responses: true) }
+  let(:backup_voice_config) { Telephony.config.pinpoint.voice_configs.last }
+
+  def mock_build_client
+    allow(voice_sender).to receive(:build_client)
+      .with(voice_config)
+      .and_return(pinpoint_client)
+  end
+
+  def mock_build_backup_client
+    allow(voice_sender).to receive(:build_client)
+      .with(backup_voice_config)
+      .and_return(backup_pinpoint_client)
+  end
+
   describe '#send' do
     let(:pinpoint_response) do
-      response = double()
-      allow(response).to receive(:message_id).and_return('fake-message-id')
-      response
+      double(message_id: 'fake-message-id')
     end
     let(:message) { 'This is a test!' }
     let(:sending_phone) { '+12223334444' }
@@ -27,10 +43,12 @@ describe Telephony::Pinpoint::VoiceSender do
     before do
       # More deterministic sending phone
       Telephony.config.pinpoint.voice_configs.first.longcode_pool = [sending_phone]
+
+      mock_build_client
     end
 
     it 'initializes a pinpoint sms and voice client and uses that to send a message' do
-      expect(voice_sender.client_configs.first.client).to receive(:send_voice_message).
+      expect(pinpoint_client).to receive(:send_voice_message).
         with(expected_message).
         and_return(pinpoint_response)
 
@@ -48,7 +66,7 @@ describe Telephony::Pinpoint::VoiceSender do
       it 'calls the user with a spanish voice' do
         expected_message[:content][:plain_text_message][:language_code] = 'es-US'
         expected_message[:content][:plain_text_message][:voice_id] = 'Miguel'
-        expect(voice_sender.client_configs.first.client).to receive(:send_voice_message).
+        expect(pinpoint_client).to receive(:send_voice_message).
           with(expected_message).
           and_return(pinpoint_response)
 
@@ -67,7 +85,7 @@ describe Telephony::Pinpoint::VoiceSender do
       it 'calls the user with a french voice' do
         expected_message[:content][:plain_text_message][:language_code] = 'fr-FR'
         expected_message[:content][:plain_text_message][:voice_id] = 'Mathieu'
-        expect(voice_sender.client_configs.first.client).to receive(:send_voice_message).
+        expect(pinpoint_client).to receive(:send_voice_message).
           with(expected_message).
           and_return(pinpoint_response)
 
@@ -84,7 +102,7 @@ describe Telephony::Pinpoint::VoiceSender do
           Seahorse::Client::RequestContext.new,
           'This is a test message',
         )
-        expect(voice_sender.client_configs.first.client)
+        expect(pinpoint_client)
           .to receive(:send_voice_message).and_raise(exception)
 
         response = voice_sender.send(message: message, to: recipient_phone)
@@ -103,7 +121,7 @@ describe Telephony::Pinpoint::VoiceSender do
           Seahorse::Client::RequestContext.new,
           'This is a test message',
         )
-        expect(voice_sender.client_configs.first.client)
+        expect(pinpoint_client)
           .to receive(:send_voice_message).and_raise(exception)
 
         response = voice_sender.send(message: message, to: recipient_phone)
@@ -122,7 +140,7 @@ describe Telephony::Pinpoint::VoiceSender do
           Seahorse::Client::RequestContext.new,
           'This is a test message',
         )
-        expect(voice_sender.client_configs.first.client)
+        expect(pinpoint_client)
           .to receive(:send_voice_message).and_raise(exception)
 
         response = voice_sender.send(message: message, to: recipient_phone)
@@ -138,7 +156,7 @@ describe Telephony::Pinpoint::VoiceSender do
     context 'when pinpoint raises a timeout exception' do
       it 'rescues the exception and returns an error' do
         exception = Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new)
-        expect(voice_sender.client_configs.first.client).
+        expect(pinpoint_client).
           to receive(:send_voice_message).and_raise(exception)
 
         response = voice_sender.send(message: message, to: recipient_phone)
@@ -158,17 +176,19 @@ describe Telephony::Pinpoint::VoiceSender do
           voice.secret_access_key = 'fake-pinpoint-secret-access-key-voice'
           voice.longcode_pool = [backup_longcode]
         end
+
+        mock_build_backup_client
       end
 
       let(:backup_longcode) { '+18881112222' }
 
       context 'when the first config succeeds' do
         before do
-          expect(voice_sender.client_configs.first.client).to receive(:send_voice_message).
+          expect(pinpoint_client).to receive(:send_voice_message).
             with(expected_message).
             and_return(pinpoint_response)
 
-          expect(voice_sender.client_configs.last.client).to_not receive(:send_voice_message)
+          expect(backup_pinpoint_client).to_not receive(:send_voice_message)
         end
 
         it 'only tries one client' do
@@ -185,12 +205,12 @@ describe Telephony::Pinpoint::VoiceSender do
             Seahorse::Client::RequestContext.new,
             'This is a test message',
           )
-          expect(voice_sender.client_configs.first.client)
+          expect(pinpoint_client)
             .to receive(:send_voice_message).and_raise(exception)
 
           # second config succeeds
           expected_message[:origination_phone_number] = backup_longcode
-          expect(voice_sender.client_configs.last.client).to receive(:send_voice_message).
+          expect(backup_pinpoint_client).to receive(:send_voice_message).
             with(expected_message).
             and_return(pinpoint_response)
         end
@@ -207,9 +227,10 @@ describe Telephony::Pinpoint::VoiceSender do
 
     context 'when all voice configs fail to build' do
       let(:raised_error_message) { 'Failed to load AWS config' }
+      let(:pinpoint_client) { nil }
+      let(:backup_pinpoint_client) { nil }
 
       it 'logs a warning and returns an error' do
-        expect(voice_sender).to receive(:client_configs).and_return([])
         expect(Telephony.config.logger).to receive(:warn)
 
         response = subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')


### PR DESCRIPTION
STS can also time out, and we'd raise into the IDP, returning a 500

These changes prevent the credential builder from failing during a call to STS and instead return a nil. The SMS/Voice senders also now handle missing/empty configuration.