### PR TITLE
Update SMS message to include origin-bound one-time code

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,10 +4,18 @@ en:
     account_reset_cancellation_notice: Your request to delete your login.gov account has been cancelled.
     account_reset_notice: As requested, your login.gov account will be deleted in 24 hours. Don't want to delete your account? Sign in to your login.gov account to cancel.
     authentication_otp:
-      sms: 'Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don''t share this code with anyone.'
+      sms: >-
+        Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+
+
+        @login.gov #%{code}
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     confirmation_otp:
-      sms: 'Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don''t share this code with anyone.'
+      sms: >-
+        Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
+
+
+        @login.gov #%{code}
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     doc_auth_link: "%{link} You've requested to verify your identity on a mobile phone.  Please take a photo of your state issued ID."
     error:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,16 +4,14 @@ en:
     account_reset_cancellation_notice: Your request to delete your login.gov account has been cancelled.
     account_reset_notice: As requested, your login.gov account will be deleted in 24 hours. Don't want to delete your account? Sign in to your login.gov account to cancel.
     authentication_otp:
-      sms: >-
+      sms: |-
         Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
-
 
         @login.gov #%{code}
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     confirmation_otp:
-      sms: >-
+      sms: |-
         Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
-
 
         @login.gov #%{code}
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,13 +7,13 @@ en:
       sms: |-
         Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
-        @login.gov #%{code}
+        @%{domain} #%{code}
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     confirmation_otp:
       sms: |-
         Login.gov: Your security code is %{code}. It expires in %{expiration} minutes. Don't share this code with anyone.
 
-        @login.gov #%{code}
+        @%{domain} #%{code}
       voice: Hello! Your login.gov one time passcode is, %{code}, again, your passcode is, %{code}. This code expires in %{expiration} minutes.
     doc_auth_link: "%{link} You've requested to verify your identity on a mobile phone.  Please take a photo of your state issued ID."
     error:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,16 +4,14 @@ es:
     account_reset_cancellation_notice: Su solicitud para eliminar su cuenta de login.gov ha sido cancelada.
     account_reset_notice: Según lo solicitado, su cuenta login.gov se eliminará en 24 horas. ¿No quieres eliminar tu cuenta? Inicie sesión en su cuenta login.gov para cancelar.
     authentication_otp:
-      sms: >-
+      sms: |-
         Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
-
 
         @login.gov #%{code}
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     confirmation_otp:
-      sms: >-
+      sms: |-
         Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
-
 
         @login.gov #%{code}
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,13 +7,13 @@ es:
       sms: |-
         Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
 
-        @login.gov #%{code}
+        @%{domain} #%{code}
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     confirmation_otp:
       sms: |-
         Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
 
-        @login.gov #%{code}
+        @%{domain} #%{code}
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     doc_auth_link: "%{link} Has solicitado verificar tu identidad en un teléfono móvil. Por favor, tome una foto de la identificación emitida por su estado"
     error:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,10 +4,18 @@ es:
     account_reset_cancellation_notice: Su solicitud para eliminar su cuenta de login.gov ha sido cancelada.
     account_reset_notice: Según lo solicitado, su cuenta login.gov se eliminará en 24 horas. ¿No quieres eliminar tu cuenta? Inicie sesión en su cuenta login.gov para cancelar.
     authentication_otp:
-      sms: 'Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.'
+      sms: >-
+        Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
+
+
+        @login.gov #%{code}
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     confirmation_otp:
-      sms: 'Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.'
+      sms: >-
+        Login.gov: Su código de seguridad es %{code}. Este código se vence en %{expiration} minutos. No lo comparta con ninguna persona.
+
+
+        @login.gov #%{code}
       voice: "¡Hola! Su código de acceso de login.gov es, %{code}, nuevamente, su código de acceso es %{code}. Este código caducará en %{expiration} minutos."
     doc_auth_link: "%{link} Has solicitado verificar tu identidad en un teléfono móvil. Por favor, tome una foto de la identificación emitida por su estado"
     error:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,16 +4,14 @@ fr:
     account_reset_cancellation_notice: Votre demande de suppression de votre compte login.gov a été annulée.
     account_reset_notice: Comme demandé, votre compte login.gov sera supprimé dans les 24 heures. Vous ne voulez pas supprimer votre compte? Connectez-vous à votre compte login.gov pour le annuler.
     authentication_otp:
-      sms: >-
+      sms: |-
         Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
-
 
         @login.gov #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     confirmation_otp:
-      sms: >-
+      sms: |-
         Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
-
 
         @login.gov #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,10 +4,18 @@ fr:
     account_reset_cancellation_notice: Votre demande de suppression de votre compte login.gov a été annulée.
     account_reset_notice: Comme demandé, votre compte login.gov sera supprimé dans les 24 heures. Vous ne voulez pas supprimer votre compte? Connectez-vous à votre compte login.gov pour le annuler.
     authentication_otp:
-      sms: 'Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.'
+      sms: >-
+        Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
+
+
+        @login.gov #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     confirmation_otp:
-      sms: 'Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.'
+      sms: >-
+        Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
+
+
+        @login.gov #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     doc_auth_link: "%{link} Vous avez demandé à vérifier votre identité sur un téléphone mobile. S'il vous plaît prendre une photo de votre identité émise par l'état"
     error:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -7,13 +7,13 @@ fr:
       sms: |-
         Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
 
-        @login.gov #%{code}
+        @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     confirmation_otp:
       sms: |-
         Login.gov: Votre code de sécurité est %{code}. Il est valable pendant %{expiration} minutes. Vous ne devez jamais partager ce code avec personne.
 
-        @login.gov #%{code}
+        @%{domain} #%{code}
       voice: Bonjour! Votre code de sécurité à utilisation unique de login.gov est, %{code}, de nouveau, votre code de sécurité est, %{code}. Ce code expirera dans %{expiration} minutes.
     doc_auth_link: "%{link} Vous avez demandé à vérifier votre identité sur un téléphone mobile. S'il vous plaît prendre une photo de votre identité émise par l'état"
     error:

--- a/lib/identity-telephony.rb
+++ b/lib/identity-telephony.rb
@@ -29,21 +29,23 @@ module Telephony
     @config
   end
 
-  def self.send_authentication_otp(to:, otp:, expiration:, channel:)
+  def self.send_authentication_otp(to:, otp:, expiration:, channel:, domain:)
     OtpSender.new(
       to: to,
       otp: otp,
       expiration: expiration,
-      channel: channel
+      channel: channel,
+      domain: domain,
     ).send_authentication_otp
   end
 
-  def self.send_confirmation_otp(to:, otp:, expiration:, channel:)
+  def self.send_confirmation_otp(to:, otp:, expiration:, channel:, domain:)
     OtpSender.new(
       to: to,
       otp: otp,
       expiration: expiration,
-      channel: channel
+      channel: channel,
+      domain: domain,
     ).send_confirmation_otp
   end
 

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -1,12 +1,13 @@
 module Telephony
   class OtpSender
-    attr_reader :recipient_phone, :otp, :expiration, :channel
+    attr_reader :recipient_phone, :otp, :expiration, :channel, :domain
 
-    def initialize(to:, otp:, expiration:, channel:)
+    def initialize(to:, otp:, expiration:, channel:, domain:)
       @recipient_phone = to
       @otp = otp
       @expiration = expiration
       @channel = channel.to_sym
+      @domain = domain
     end
 
     def send_authentication_otp
@@ -55,6 +56,7 @@ module Telephony
         "telephony.authentication_otp.#{channel}",
         code: otp_transformed_for_channel,
         expiration: expiration,
+        domain: domain,
       )
     end
 
@@ -63,6 +65,7 @@ module Telephony
         "telephony.confirmation_otp.#{channel}",
         code: otp_transformed_for_channel,
         expiration: expiration,
+        domain: domain,
       )
     end
 

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.1.12'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/lib/otp_sender/pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/pinpoint_adapter_spec.rb
@@ -14,7 +14,7 @@ describe Telephony::OtpSender do
       let(:channel) { :sms }
 
       it 'sends an authentication OTP with Pinpoint SMS' do
-        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone."
+        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone.\n\n@login.gov #123456"
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)
@@ -24,7 +24,7 @@ describe Telephony::OtpSender do
       end
 
       it 'sends a confirmation OTP with Pinpoint SMS' do
-        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone."
+        message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone.\n\n@login.gov #123456"
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
         expect(adapter).to receive(:send).with(message: message, to: to)

--- a/spec/lib/otp_sender/pinpoint_adapter_spec.rb
+++ b/spec/lib/otp_sender/pinpoint_adapter_spec.rb
@@ -1,10 +1,19 @@
 describe Telephony::OtpSender do
   context 'with the pinpoint adapter' do
-    subject { described_class.new(to: to, otp: otp, expiration: expiration, channel: channel) }
+    subject do
+      described_class.new(
+        to: to,
+        otp: otp,
+        expiration: expiration,
+        channel: channel,
+        domain: domain,
+      )
+    end
 
     let(:to) { '+1 (202) 262-1234' }
     let(:otp) { '123456' }
     let(:expiration) { 5 }
+    let(:domain) { 'login.gov' }
 
     before do
       allow(Telephony.config).to receive(:adapter).and_return(:pinpoint)

--- a/spec/lib/otp_sender/test_adapter_spec.rb
+++ b/spec/lib/otp_sender/test_adapter_spec.rb
@@ -5,11 +5,20 @@ describe Telephony::OtpSender do
   end
 
   context 'with the test adapter' do
-    subject { described_class.new(to: to, otp: otp, expiration: expiration, channel: channel) }
+    subject do
+      described_class.new(
+        to: to,
+        otp: otp,
+        expiration: expiration,
+        channel: channel,
+        domain: domain,
+      )
+    end
 
     let(:to) { '+1 (202) 262-1234' }
     let(:otp) { '123456' }
     let(:expiration) { 5 }
+    let(:domain) { 'login.gov' }
 
     before do
       allow(Telephony.config).to receive(:adapter).and_return(:test)


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/4915

**Why**: To be able to make use of WebOTP to allow users of Android devices to autofill the received code, and to enhance the security of SMS codes by taking advantage of domain restrictions.

>When you use a domain-bound code, AutoFill will suggest the code if — and only if — the domain is a match for the website or one of your app’s associated domains.

Resources:
- https://developer.apple.com/news/?id=z0i801mg
- https://wicg.github.io/sms-one-time-codes/#origin-bound-one-time-code-message
- https://wicg.github.io/web-otp/