### PR TITLE
Set SMS sender ID via config (LG-3121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Telephony.config do |c|
   c.voice_pause_time = '0.5s'
   c.voice_rate = 'slow'
 
+  c.sender_id = 'some_sender_id'
+
   c.pinpoint.add_sms_config do |sms|
     sms.region = 'us-west-2' # This is optional, us-west-2 is the default
     sms.application_id = 'fake-pinpoint-application-id-sms'

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -52,6 +52,7 @@ module Telephony
     attr_accessor :logger
     attr_accessor :voice_pause_time
     attr_accessor :voice_rate
+    attr_accessor :sender_id
 
     # rubocop:disable Metrics/MethodLength
     def initialize

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -37,6 +37,7 @@ module Telephony
                   body: message,
                   message_type: 'TRANSACTIONAL',
                   origination_number: sms_config.shortcode,
+                  sender_id: Telephony.config.sender_id,
                 },
               },
             },

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/lib/pinpoint/sms_sender_spec.rb
+++ b/spec/lib/pinpoint/sms_sender_spec.rb
@@ -144,6 +144,12 @@ describe Telephony::Pinpoint::SmsSender do
   end
 
   describe '#send' do
+    let(:sender_id) { 'abcdef' }
+
+    before do
+      allow(Telephony.config).to receive(:sender_id).and_return(sender_id)
+    end
+
     it 'initializes a pinpoint client and uses that to send a message with a shortcode' do
       mock_build_client
       response = subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')
@@ -159,6 +165,7 @@ describe Telephony::Pinpoint::SmsSender do
               body: 'This is a test!',
               message_type: 'TRANSACTIONAL',
               origination_number: '123456',
+              sender_id: sender_id,
             },
           },
         },


### PR DESCRIPTION
the sender ID is required to send SMS to certain countries