### PR TITLE
Per-country sender ID (LG-5060)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Telephony.config do |c|
   c.voice_pause_time = '0.5s'
   c.voice_rate = 'slow'
 
-  c.sender_id = 'some_sender_id'
+  c.country_sender_ids = {
+    US: 'sender1',
+    CA: 'sender2',
+  }
 
   c.pinpoint.add_sms_config do |sms|
     sms.region = 'us-west-2' # This is optional, us-west-2 is the default

--- a/lib/identity-telephony.rb
+++ b/lib/identity-telephony.rb
@@ -29,23 +29,25 @@ module Telephony
     @config
   end
 
-  def self.send_authentication_otp(to:, otp:, expiration:, channel:, domain:)
+  def self.send_authentication_otp(to:, otp:, expiration:, channel:, domain:, country_code:)
     OtpSender.new(
       to: to,
       otp: otp,
       expiration: expiration,
       channel: channel,
       domain: domain,
+      country_code: country_code,
     ).send_authentication_otp
   end
 
-  def self.send_confirmation_otp(to:, otp:, expiration:, channel:, domain:)
+  def self.send_confirmation_otp(to:, otp:, expiration:, channel:, domain:, country_code:)
     OtpSender.new(
       to: to,
       otp: otp,
       expiration: expiration,
       channel: channel,
       domain: domain,
+      country_code: country_code,
     ).send_confirmation_otp
   end
 

--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -2,23 +2,23 @@ module Telephony
   class AlertSender
     SMS_MAX_LENGTH = 160
 
-    def send_account_reset_notice(to:)
+    def send_account_reset_notice(to:, country_code:)
       message = I18n.t('telephony.account_reset_notice')
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response
     end
 
-    def send_account_reset_cancellation_notice(to:)
+    def send_account_reset_cancellation_notice(to:, country_code:)
       message = I18n.t('telephony.account_reset_cancellation_notice')
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response
     end
 
-    def send_doc_auth_link(to:, link:)
+    def send_doc_auth_link(to:, link:, country_code:)
       message = I18n.t('telephony.doc_auth_link', link: link)
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       context = __method__.to_s.gsub(/^send_/, '')
       if link.length > SMS_MAX_LENGTH
         log_warning("link longer than #{SMS_MAX_LENGTH} characters", context: context)
@@ -27,37 +27,37 @@ module Telephony
       response
     end
 
-    def send_personal_key_regeneration_notice(to:)
+    def send_personal_key_regeneration_notice(to:, country_code:)
       message = I18n.t('telephony.personal_key_regeneration_notice')
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response
     end
 
-    def send_personal_key_sign_in_notice(to:)
+    def send_personal_key_sign_in_notice(to:, country_code:)
       message = I18n.t('telephony.personal_key_sign_in_notice')
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response
     end
 
-    def send_join_keyword_response(to:)
+    def send_join_keyword_response(to:, country_code:)
       message = I18n.t('telephony.join_keyword_response')
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response
     end
 
-    def send_stop_keyword_response(to:)
+    def send_stop_keyword_response(to:, country_code:)
       message = I18n.t('telephony.stop_keyword_response')
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response
     end
 
-    def send_help_keyword_response(to:)
+    def send_help_keyword_response(to:, country_code:)
       message = I18n.t('telephony.help_keyword_response')
-      response = adapter.send(message: message, to: to)
+      response = adapter.send(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
       response
     end

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -65,8 +65,9 @@ module Telephony
       @adapter.to_sym
     end
 
+    # @param [Hash,nil] map
     def country_sender_ids=(hash)
-      @country_sender_ids = hash.transform_keys(&:to_s)
+      @country_sender_ids = hash&.transform_keys(&:to_s)
     end
 
     def country_sender_ids

--- a/lib/telephony/configuration.rb
+++ b/lib/telephony/configuration.rb
@@ -52,7 +52,6 @@ module Telephony
     attr_accessor :logger
     attr_accessor :voice_pause_time
     attr_accessor :voice_rate
-    attr_accessor :sender_id
 
     # rubocop:disable Metrics/MethodLength
     def initialize
@@ -64,6 +63,14 @@ module Telephony
 
     def adapter
       @adapter.to_sym
+    end
+
+    def country_sender_ids=(hash)
+      @country_sender_ids = hash.transform_keys(&:to_s)
+    end
+
+    def country_sender_ids
+      @country_sender_ids || {}
     end
   end
 end

--- a/lib/telephony/otp_sender.rb
+++ b/lib/telephony/otp_sender.rb
@@ -1,23 +1,24 @@
 module Telephony
   class OtpSender
-    attr_reader :recipient_phone, :otp, :expiration, :channel, :domain
+    attr_reader :recipient_phone, :otp, :expiration, :channel, :domain, :country_code
 
-    def initialize(to:, otp:, expiration:, channel:, domain:)
+    def initialize(to:, otp:, expiration:, channel:, domain:, country_code:)
       @recipient_phone = to
       @otp = otp
       @expiration = expiration
       @channel = channel.to_sym
       @domain = domain
+      @country_code = country_code
     end
 
     def send_authentication_otp
-      response = adapter.send(message: authentication_message, to: recipient_phone, otp: otp)
+      response = adapter.send(message: authentication_message, to: recipient_phone, otp: otp, country_code: country_code)
       log_response(response, context: :authentication)
       response
     end
 
     def send_confirmation_otp
-      response = adapter.send(message: confirmation_message, to: recipient_phone, otp: otp)
+      response = adapter.send(message: confirmation_message, to: recipient_phone, otp: otp, country_code: country_code)
       log_response(response, context: :confirmation)
       response
     end

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -16,7 +16,7 @@ module Telephony
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
       # @return [Response]
-      def send(message:, to:, otp: nil)
+      def send(message:, to:, country_code:, otp: nil)
         return handle_config_failure if Telephony.config.pinpoint.sms_configs.empty?
 
         response = nil
@@ -37,7 +37,7 @@ module Telephony
                   body: message,
                   message_type: 'TRANSACTIONAL',
                   origination_number: sms_config.shortcode,
-                  sender_id: Telephony.config.sender_id,
+                  sender_id: Telephony.config.country_sender_ids[country_code.to_s],
                 },
               },
             },

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -5,7 +5,7 @@ module Telephony
   module Pinpoint
     class VoiceSender
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
-      def send(message:, to:, otp: nil)
+      def send(message:, to:, country_code:, otp: nil)
         return handle_config_failure if Telephony.config.pinpoint.voice_configs.empty?
 
         language_code, voice_id = language_code_and_voice_id

--- a/lib/telephony/test/sms_sender.rb
+++ b/lib/telephony/test/sms_sender.rb
@@ -1,7 +1,7 @@
 module Telephony
   module Test
     class SmsSender
-      def send(message:, to:, otp: nil)
+      def send(message:, to:, country_code:, otp: nil)
         error = ErrorSimulator.new.error_for_number(to)
         if error.nil?
           Message.messages.push(Message.new(body: message, to: to, otp: otp))

--- a/lib/telephony/test/voice_sender.rb
+++ b/lib/telephony/test/voice_sender.rb
@@ -1,7 +1,7 @@
 module Telephony
   module Test
     class VoiceSender
-      def send(message:, to:, otp: nil)
+      def send(message:, to:, country_code:, otp: nil)
         error = ErrorSimulator.new.error_for_number(to)
         if error.nil?
           Call.calls.push(Call.new(body: message, to: to, otp: otp))

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/lib/alert_sender_spec.rb
+++ b/spec/lib/alert_sender_spec.rb
@@ -9,7 +9,7 @@ describe Telephony::AlertSender do
 
   describe 'send_account_reset_notice' do
     it 'sends the correct message' do
-      subject.send_account_reset_notice(to: recipient)
+      subject.send_account_reset_notice(to: recipient, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -21,7 +21,7 @@ describe Telephony::AlertSender do
 
   describe 'send_account_reset_cancellation_notice' do
     it 'sends the correct message' do
-      subject.send_account_reset_cancellation_notice(to: recipient)
+      subject.send_account_reset_cancellation_notice(to: recipient, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -35,7 +35,7 @@ describe Telephony::AlertSender do
     end
 
     it 'sends the correct message' do
-      subject.send_doc_auth_link(to: recipient, link: link)
+      subject.send_doc_auth_link(to: recipient, link: link, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -53,7 +53,7 @@ describe Telephony::AlertSender do
         end
 
         it 'puts the URL in the first 160 characters, so it stays within a single SMS message' do
-          subject.send_doc_auth_link(to: recipient, link: link)
+          subject.send_doc_auth_link(to: recipient, link: link, country_code: 'US')
 
           last_message = Telephony::Test::Message.messages.last
           first160 = last_message.body[0...160]
@@ -67,13 +67,13 @@ describe Telephony::AlertSender do
 
       expect(Telephony.config.logger).to receive(:warn)
 
-      subject.send_doc_auth_link(to: recipient, link: long_link)
+      subject.send_doc_auth_link(to: recipient, link: long_link, country_code: 'US')
     end
   end
 
   describe 'send_personal_key_regeneration_notice' do
     it 'sends the correct message' do
-      subject.send_personal_key_regeneration_notice(to: recipient)
+      subject.send_personal_key_regeneration_notice(to: recipient, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -83,7 +83,7 @@ describe Telephony::AlertSender do
 
   describe 'send_personal_key_sign_in_notice' do
     it 'sends the correct message' do
-      subject.send_personal_key_sign_in_notice(to: recipient)
+      subject.send_personal_key_sign_in_notice(to: recipient, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -93,7 +93,7 @@ describe Telephony::AlertSender do
 
   describe 'send_join_keyword_response' do
     it 'sends the correct message' do
-      subject.send_join_keyword_response(to: recipient)
+      subject.send_join_keyword_response(to: recipient, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -103,7 +103,7 @@ describe Telephony::AlertSender do
 
   describe 'send_stop_keyword_response' do
     it 'sends the correct message' do
-      subject.send_stop_keyword_response(to: recipient)
+      subject.send_stop_keyword_response(to: recipient, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -113,7 +113,7 @@ describe Telephony::AlertSender do
 
   describe 'send_help_keyword_response' do
     it 'sends the correct message' do
-      subject.send_help_keyword_response(to: recipient)
+      subject.send_help_keyword_response(to: recipient, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
@@ -129,10 +129,11 @@ describe Telephony::AlertSender do
       expect(adapter).to receive(:send).with(
         message: I18n.t('telephony.join_keyword_response'),
         to: recipient,
+        country_code: 'US',
       )
       expect(Telephony::Pinpoint::SmsSender).to receive(:new).and_return(adapter)
 
-      subject.send_join_keyword_response(to: recipient)
+      subject.send_join_keyword_response(to: recipient, country_code: 'US')
     end
   end
 end

--- a/spec/lib/otp_sender_spec.rb
+++ b/spec/lib/otp_sender_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Telephony::OtpSender do
         expiration: expiration,
         channel: channel,
         domain: domain,
+        country_code: country_code,
       )
     end
 
@@ -21,6 +22,7 @@ RSpec.describe Telephony::OtpSender do
     let(:otp) { '123456' }
     let(:expiration) { 5 }
     let(:domain) { 'login.gov' }
+    let(:country_code) { 'US' }
 
     before do
       allow(Telephony.config).to receive(:adapter).and_return(:test)
@@ -67,6 +69,7 @@ RSpec.describe Telephony::OtpSender do
         expiration: expiration,
         channel: channel,
         domain: domain,
+        country_code: country_code,
       )
     end
 
@@ -74,6 +77,7 @@ RSpec.describe Telephony::OtpSender do
     let(:otp) { '123456' }
     let(:expiration) { 5 }
     let(:domain) { 'login.gov' }
+    let(:country_code) { 'US' }
 
     before do
       allow(Telephony.config).to receive(:adapter).and_return(:pinpoint)
@@ -86,7 +90,7 @@ RSpec.describe Telephony::OtpSender do
         message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone.\n\n@login.gov #123456"
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
-        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp)
+        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp, country_code: 'US')
         expect(Telephony::Pinpoint::SmsSender).to receive(:new).and_return(adapter)
 
         subject.send_authentication_otp
@@ -96,7 +100,7 @@ RSpec.describe Telephony::OtpSender do
         message = "Login.gov: Your security code is 123456. It expires in 5 minutes. Don't share this code with anyone.\n\n@login.gov #123456"
 
         adapter = instance_double(Telephony::Pinpoint::SmsSender)
-        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp)
+        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp, country_code: 'US')
         expect(Telephony::Pinpoint::SmsSender).to receive(:new).and_return(adapter)
 
         subject.send_confirmation_otp
@@ -122,7 +126,7 @@ RSpec.describe Telephony::OtpSender do
         XML
 
         adapter = instance_double(Telephony::Pinpoint::VoiceSender)
-        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp)
+        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp, country_code: country_code)
         expect(Telephony::Pinpoint::VoiceSender).to receive(:new).and_return(adapter)
 
         subject.send_confirmation_otp
@@ -144,7 +148,7 @@ RSpec.describe Telephony::OtpSender do
         XML
 
         adapter = instance_double(Telephony::Pinpoint::VoiceSender)
-        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp)
+        expect(adapter).to receive(:send).with(message: message, to: to, otp: otp, country_code: country_code)
         expect(Telephony::Pinpoint::VoiceSender).to receive(:new).and_return(adapter)
 
         subject.send_confirmation_otp
@@ -166,6 +170,7 @@ RSpec.describe Telephony::OtpSender do
   end
 
   describe '#otp_transformed_for_channel' do
+    let(:country_code) { 'US' }
     let(:otp_sender) do
       Telephony::OtpSender.new(
         to: '+18888675309',
@@ -173,6 +178,7 @@ RSpec.describe Telephony::OtpSender do
         channel: channel,
         expiration: Time.now,
         domain: 'login.gov',
+        country_code: country_code,
       )
     end
 

--- a/spec/lib/pinpoint/voice_sender_spec.rb
+++ b/spec/lib/pinpoint/voice_sender_spec.rb
@@ -52,7 +52,7 @@ describe Telephony::Pinpoint::VoiceSender do
         with(expected_message).
         and_return(pinpoint_response)
 
-      response = voice_sender.send(message: message, to: recipient_phone)
+      response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
 
       expect(response.success?).to eq(true)
       expect(response.extra[:message_id]).to eq('fake-message-id')
@@ -70,7 +70,7 @@ describe Telephony::Pinpoint::VoiceSender do
           with(expected_message).
           and_return(pinpoint_response)
 
-        response = voice_sender.send(message: message, to: recipient_phone)
+        response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
 
         expect(response.success?).to eq(true)
         expect(response.extra[:message_id]).to eq('fake-message-id')
@@ -89,7 +89,7 @@ describe Telephony::Pinpoint::VoiceSender do
           with(expected_message).
           and_return(pinpoint_response)
 
-        response = voice_sender.send(message: message, to: recipient_phone)
+        response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
 
         expect(response.success?).to eq(true)
         expect(response.extra[:message_id]).to eq('fake-message-id')
@@ -105,7 +105,7 @@ describe Telephony::Pinpoint::VoiceSender do
         expect(pinpoint_client)
           .to receive(:send_voice_message).and_raise(exception)
 
-        response = voice_sender.send(message: message, to: recipient_phone)
+        response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
 
         error_message =
           'Aws::PinpointSMSVoice::Errors::LimitExceededException: This is a test message'
@@ -124,7 +124,7 @@ describe Telephony::Pinpoint::VoiceSender do
         expect(pinpoint_client)
           .to receive(:send_voice_message).and_raise(exception)
 
-        response = voice_sender.send(message: message, to: recipient_phone)
+        response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
 
         error_message =
           'Aws::PinpointSMSVoice::Errors::InternalServiceErrorException: This is a test message'
@@ -143,7 +143,7 @@ describe Telephony::Pinpoint::VoiceSender do
         expect(pinpoint_client)
           .to receive(:send_voice_message).and_raise(exception)
 
-        response = voice_sender.send(message: message, to: recipient_phone)
+        response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
 
         error_message =
           'Aws::PinpointSMSVoice::Errors::BadRequestException: This is a test message'
@@ -159,7 +159,7 @@ describe Telephony::Pinpoint::VoiceSender do
         expect(pinpoint_client).
           to receive(:send_voice_message).and_raise(exception)
 
-        response = voice_sender.send(message: message, to: recipient_phone)
+        response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
 
         error_message = 'Seahorse::Client::NetworkingError: Net::ReadTimeout'
 
@@ -192,7 +192,7 @@ describe Telephony::Pinpoint::VoiceSender do
         end
 
         it 'only tries one client' do
-          response = voice_sender.send(message: message, to: recipient_phone)
+          response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
           expect(response.success?).to eq(true)
           expect(response.extra[:message_id]).to eq('fake-message-id')
         end
@@ -218,7 +218,7 @@ describe Telephony::Pinpoint::VoiceSender do
         it 'logs a warning and tries the other configs' do
           expect(Telephony.config.logger).to receive(:warn)
 
-          response = voice_sender.send(message: message, to: recipient_phone)
+          response = voice_sender.send(message: message, to: recipient_phone, country_code: 'US')
           expect(response.success?).to eq(true)
           expect(response.extra[:message_id]).to eq('fake-message-id')
         end
@@ -233,7 +233,7 @@ describe Telephony::Pinpoint::VoiceSender do
       it 'logs a warning and returns an error' do
         expect(Telephony.config.logger).to receive(:warn)
 
-        response = subject.send(message: 'This is a test!', to: '+1 (123) 456-7890')
+        response = subject.send(message: 'This is a test!', to: '+1 (123) 456-7890', country_code: 'US')
         expect(response.success?).to eq(false)
         expect(response.error).to eq(Telephony::UnknownFailureError.new(raised_error_message))
       end

--- a/spec/lib/test/sms_sender_spec.rb
+++ b/spec/lib/test/sms_sender_spec.rb
@@ -3,14 +3,14 @@ describe Telephony::Test::SmsSender do
     Telephony::Test::Message.clear_messages
   end
 
-  subject(:sms_sender) {Telephony::Test::SmsSender.new }
+  subject(:sms_sender) { Telephony::Test::SmsSender.new }
 
   describe '#send' do
     it 'adds the message to the message stack' do
       message_body = 'This is a test'
       phone = '+1 (202) 555-5000'
 
-      response = subject.send(message: message_body, to: phone)
+      response = subject.send(message: message_body, to: phone, country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
 
@@ -23,7 +23,7 @@ describe Telephony::Test::SmsSender do
     end
 
     it 'simulates a telephony error' do
-      response = subject.send(message: 'test', to: '+1 (225) 555-1000')
+      response = subject.send(message: 'test', to: '+1 (225) 555-1000', country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
 
@@ -34,7 +34,7 @@ describe Telephony::Test::SmsSender do
     end
 
     it 'simulates an invalid calling area error' do
-      response = subject.send(message: 'test', to: '+1 (225) 555-2000')
+      response = subject.send(message: 'test', to: '+1 (225) 555-2000', country_code: 'US')
 
       last_message = Telephony::Test::Message.messages.last
 

--- a/spec/lib/test/voice_sender_spec.rb
+++ b/spec/lib/test/voice_sender_spec.rb
@@ -8,7 +8,7 @@ describe Telephony::Test::VoiceSender do
       call_body = 'This is a test'
       phone = '+1 (202) 555-5000'
 
-      response = subject.send(message: call_body, to: phone)
+      response = subject.send(message: call_body, to: phone, country_code: 'US')
 
       last_call = Telephony::Test::Call.calls.last
 
@@ -20,7 +20,7 @@ describe Telephony::Test::VoiceSender do
     end
 
     it 'simulates a telephony error' do
-      response = subject.send(message: 'test', to: '+1 (225) 555-1000')
+      response = subject.send(message: 'test', to: '+1 (225) 555-1000', country_code: 'US')
 
       last_call = Telephony::Test::Call.calls.last
 
@@ -31,7 +31,7 @@ describe Telephony::Test::VoiceSender do
     end
 
     it 'simulates an invalid calling area error' do
-      response = subject.send(message: 'test', to: '+1 (225) 555-2000')
+      response = subject.send(message: 'test', to: '+1 (225) 555-2000', country_code: 'US')
 
       last_call = Telephony::Test::Call.calls.last
 


### PR DESCRIPTION
I chose to add `country_code` as a param instead of adding a dependency on Phonelib to parse the numbers inside the gem, which added a lot of noise to the diff.

We're planning to move this back inside the IDP, so maybe it would't be that bad to depend on Phonelib? Open to feedback here,