### PR TITLE
rescue TooManyRequestsException when sending SMS

### DIFF
--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -50,7 +50,7 @@ module Telephony
             region: sms_config.region,
             extra: response.extra,
           )
-        rescue Seahorse::Client::NetworkingError => e
+        rescue Aws::Pinpoint::Errors::TooManyRequestsException, Seahorse::Client::NetworkingError => e
           finish = Time.now
           response = handle_pinpoint_error(e)
           notify_pinpoint_failover(

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
We saw a handful of these despite a normal level of traffic ([NR link](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=604800000&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiNzdmMjJjYWMtMTNkNy0xMWVjLWFlY2QtMDI0MmFjMTEwMDBhXzBfMTg4MjMiLCJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXciLCJlbnRpdHlHdWlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThOVEl4TXpZNE5UZyJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5R3VpZCI6Ik1UTTNOak0zTUh4QlVFMThRVkJRVEVsRFFWUkpUMDU4TlRJeE16WTROVGciLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoiZXJyb3JzLXVpLm92ZXJ2aWV3In19&state=551090d3-11ea-f755-ef02-359c84a0803f)). It's not clear if it's similar to the `Aws::PinpointSMSVoice::Errors::LimitExceededException` we rescue for voice [here](https://github.com/18F/identity-telephony/blob/main/lib/telephony/pinpoint/voice_sender.rb#L77), but the logs don't show any odd patterns for request rates. There is a bit of overlap with some increased latency from Pinpoint though, so that may be a factor. Regardless, we shouldn't 500.