### PR TITLE
Rescue internal server error exception when sending SMS

### DIFF
--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -50,7 +50,8 @@ module Telephony
             region: sms_config.region,
             extra: response.extra,
           )
-        rescue Aws::Pinpoint::Errors::TooManyRequestsException, Seahorse::Client::NetworkingError => e
+        rescue Aws::Pinpoint::Errors::InternalServerErrorException, Aws::Pinpoint::Errors::TooManyRequestsException,
+          Seahorse::Client::NetworkingError => e
           finish = Time.now
           response = handle_pinpoint_error(e)
           notify_pinpoint_failover(

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end


### PR DESCRIPTION
Similar to #52, but for getting an internal server error

[NR Link](https://one.newrelic.com/launcher/nr1-core.explorer?platform[accountId]=1376370&platform[timeRange][duration]=604800000&pane=eyJiYXJjaGFydCI6ImJhcmNoYXJ0IiwidG9wRmFjZXQiOiJ0cmFuc2FjdGlvblVpTmFtZSIsInBhZ2UiOiJzaG93IiwicHJpbWFyeUZhY2V0IjoiZXJyb3IuY2xhc3MiLCJ0cmFjZUlkIjoiZWIxNzllNzctMWEzOS0xMWVjLTk2MGYtMDI0MmFjMTEwMDA4XzBfMTg5NjkiLCJuZXJkbGV0SWQiOiJlcnJvcnMtdWkub3ZlcnZpZXciLCJlbnRpdHlHdWlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThOVEl4TXpZNE5UZyJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImVycm9ycy11aS5vdmVydmlldyJ9LCJlbnRpdHlHdWlkIjoiTVRNM05qTTNNSHhCVUUxOFFWQlFURWxEUVZSSlQwNThOVEl4TXpZNE5UZyJ9&state=84b16e06-145d-6379-e4e3-81cc4d687654)