### PR TITLE
Update copy for stop SMS to be less than 160 chars (LG-1926)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,4 +34,4 @@ en:
     join_keyword_response: 123456 is your login.gov confirmation code. Use this to confirm your phone number. This code will expire in 5 minutes.
     personal_key_regeneration_notice: A new personal key has been issued for your login.gov account. If this wasn’t you, reset your password.
     personal_key_sign_in_notice: Your personal key was just used to sign into your login.gov account. If this wasn’t you, reset your password.
-    stop_keyword_response: You've unsubscribed from login.gov alerts. You will no longer receive alerts unless you resubscribe by using this phone number to sign in or set up an account. Reply HELP for help or see www.login.gov/help.
+    stop_keyword_response: You have unsubscribed and will not receive alerts from login.gov . To resubscribe, sign in or set up an account. Help? www.login.gov/help

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -34,4 +34,4 @@ es:
     join_keyword_response: 123456 es tu código de confirmación de login.gov. Use esto para confirmar su número de teléfono. Este código caducará en 5 minutos.
     personal_key_regeneration_notice: Se ha emitido una nueva clave personal para tu cuenta login.gov. Si no eres tú, restablece tu contraseña.
     personal_key_sign_in_notice: Su clave personal solo se utilizó para iniciar sesión en su cuenta login.gov. Si no fue así, reinicie su contraseña.
-    stop_keyword_response: Ha cancelado la suscripción a las alertas de login.gov. Ya no recibirá alertas a menos que vuelva a suscribirse utilizando este número de teléfono para iniciar sesión o configurar una cuenta. Responda HELP para obtener ayuda o visite www.login.gov/help.
+    stop_keyword_response: Ha anulado su suscripción y no recibirá alertas de login.gov. Para volver a suscribirse, inicie sesión o cree una cuenta. ¿Necesita ayuda? www.login.gov/help

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -34,4 +34,4 @@ fr:
     join_keyword_response: 123456 est votre code de confirmation login.gov. Utilisez-le pour confirmer votre numéro de téléphone. Ce code expirera dans 5 minutes.
     personal_key_regeneration_notice: Une nouvelle clé personnelle a été émise pour votre compte login.gov. Si vous ne l'avez pas demandée, réinitialisez votre mot de passe.
     personal_key_sign_in_notice: Votre clé personnelle a été utilisée pour vous connecter à votre compte login.gov. Si ce n’était pas vous, changez votre mot de passe.
-    stop_keyword_response: Vous avez désabonné des alertes de login.gov. Vous ne recevrez plus d'alertes sauf si vous vous réabonnez en utilisant ce numéro de téléphone pour vous connecter ou créer un compte. Répondez à HELP pour obtenir de l'aide ou visitez www.login.gov/help.
+    stop_keyword_response: Vous vous êtes désinscrit et ne recevrez plus d'alertes de Login.gov. Pour vous réabonner, connectez-vous ou créez un compte. Besoin d'aide? www.login.gov/help

--- a/lib/telephony/version.rb
+++ b/lib/telephony/version.rb
@@ -1,3 +1,3 @@
 module Telephony
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end

--- a/spec/lib/alert_sender_spec.rb
+++ b/spec/lib/alert_sender_spec.rb
@@ -42,7 +42,7 @@ describe Telephony::AlertSender do
       expect(last_message.body).to eq(I18n.t('telephony.doc_auth_link', link: link))
     end
 
-    ['en', 'es', 'fr'].each do |locale|
+    I18n.available_locales.each do |locale|
       context "in locale #{locale}" do
         around do |ex|
           orig_locale = I18n.locale
@@ -108,6 +108,25 @@ describe Telephony::AlertSender do
       last_message = Telephony::Test::Message.messages.last
       expect(last_message.to).to eq(recipient)
       expect(last_message.body).to eq(I18n.t('telephony.stop_keyword_response'))
+    end
+
+    I18n.available_locales.each do |locale|
+      context "in locale #{locale}" do
+        around do |ex|
+          orig_locale = I18n.locale
+          I18n.locale = locale
+          ex.run
+        ensure
+          I18n.locale = orig_locale
+        end
+
+        it 'fits in an SMS messages (160 chars)' do
+          subject.send_stop_keyword_response(to: recipient, country_code: 'US')
+
+          last_message = Telephony::Test::Message.messages.last
+          expect(last_message.body.size).to be <= 160
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,8 @@ end
 
 WebMock.disable_net_connect!
 
+I18n.available_locales = [:en, :es, :fr]
+
 # Raise missing translation errors in the specs so that missing translations
 # will trigger a test failure
 I18n.exception_handler = lambda do |exception, _locale, _key, _options|


### PR DESCRIPTION
- [x] translate spanish